### PR TITLE
Correction erreur en cascade qui empêche l'écran d'accueil

### DIFF
--- a/scripts/front-end/actions/main.js
+++ b/scripts/front-end/actions/main.js
@@ -20,7 +20,7 @@ export function chargerDossiers(){
             })
     }
     else{
-        return Promise.reject('Impossible de charger les dossiers, secret manquant')
+        return Promise.reject(new TypeError('Impossible de charger les dossiers, secret manquant'))
     }
 }
 


### PR DESCRIPTION
En envoyant uniquement une string, on prend une erreur quand on cherche, plus loin la propriété "message" de cette erreur, ce qui fait planter l'ensemble et empêche l'affichage de l'écran de login