### PR TITLE
Ajout de la page pour créer le lien de préremplissage sur DS

### DIFF
--- a/scripts/front-end/components/screens/PreremplissageDerogation.svelte
+++ b/scripts/front-end/components/screens/PreremplissageDerogation.svelte
@@ -1,11 +1,126 @@
 <script>
+    import { créerLienPréremplissageDémarche } from '../../../commun/préremplissageDémarcheSimplifiée';
     import Squelette from '../Squelette.svelte'
+    import Loader from '../Loader.svelte'
+    import { json } from 'd3-fetch';
+    import { isFuture } from 'date-fns/isFuture';
+
+    /** @import {DossierDémarcheSimplifiée88444} from "../../../types.js" */
+
+    /** @type {DossierDémarcheSimplifiée88444} */
+    let nouveauDossierPartiel = {}
+    let lienDePreremplissage = ""
+    $: champsPreremplis = Object.keys(nouveauDossierPartiel).filter(champ => {
+        return nouveauDossierPartiel[champ] != ""
+    })
+
+    let onSelectChanged = (e) => {
+        lienDePreremplissage = créerLienPréremplissageDémarche(nouveauDossierPartiel)
+    }
+
+    const démarcheSimplifiée88444SchemaPath = '../../../../data/schema-DS-88444.json'
+    const champsPossibles = [
+        "DropDownListChampDescriptor",
+        "MultipleDropDownListChampDescriptor",
+        "YesNoChampDescriptor",
+        "CheckboxChampDescriptor",
+    ]
+    
+    let champsRemplissablesP = json(démarcheSimplifiée88444SchemaPath).then((schema) => {
+        return schema["revision"]["champDescriptors"].filter((champ) => {
+            return champsPossibles.includes(champ["__typename"])
+        })
+    })
 </script>
 
 <Squelette>
-    <div class="fr-grid-row fr-pt-6w fr-grid-row--center">
-        <div class="fr-col">
+    <div class="fr-grid-row fr-grid-row--center">
+        <div class="fr-col-8">
             <h1>Pré-remplissage dérogation espèces protégées</h1>
+
+            {#await champsRemplissablesP}
+                <Loader />
+            {:then champsRemplissables}
+                <form>
+                    {#each champsRemplissables as champ}
+                        <fieldset class="fr-fieldset fr-p-1-5v">
+                            <div class="fr-fieldset__element">
+                                <div class="fr-input-group">
+                                    <label class="fr-label" for="{champ["label"]}">
+                                        {champ["label"]} 
+                                        {#if nouveauDossierPartiel[champ["label"]]}
+                                        ✅
+                                        {/if}
+                                    </label>
+
+                                    <select 
+                                        bind:value={nouveauDossierPartiel[champ["label"]]} 
+                                        on:change={onSelectChanged}
+                                        id="{champ["label"]}"
+                                        class="fr-select"
+                                    >
+                                        {#if champ["options"]}
+                                            <option value="" selected></option>
+                                            {#each champ["options"] as option}
+                                                <option value="{option}">{option}</option>
+                                            {/each}
+                                        {:else}
+                                            <option value="" selected></option>
+                                            <option value="false">non</option>
+                                            <option value="true">oui</option>
+                                        {/if}
+                                    </select>
+                                </div>
+                            </div>
+                        </fieldset>
+                    {/each}
+                </form>
+
+                <div class="fr-callout fr-callout--brown-caramel">
+                    <h3 class="fr-callout__title">Votre lien de préremplissage pour une dérogation espèces protégées</h3>
+
+                    <div class="fr-callout__text">
+                        {#if champsPreremplis.length > 0}
+                            <p class="fr-mt-2w">
+                                La liste des éléments que vous avez pré-remplis avec ce lien :
+                            </p>
+                            <ul>
+                                {#each champsPreremplis as champPrerempli}
+                                    <li>
+                                        {champPrerempli} : 
+                                        <em>{nouveauDossierPartiel[champPrerempli]}</em>
+                                    </li>
+                                {/each}
+                            </ul>
+                            <pre>
+                                <code class="code-block">{lienDePreremplissage}</code>
+                            </pre>
+                        {:else}
+                            <p class="fr-mt-2w">
+                                Vous n'avez encore pré-rempli aucun champ de la dérogation. Vous pouvez sélectionnez des options ci-dessus afin d'obtenir votre lien de pré-remplissage.
+                            </p>
+                        {/if}
+                    </div>
+                </div>
+            {/await}
         </div>
+
     </div>
 </Squelette>
+
+<style lang="scss">
+    .selected { 
+        background-color: red;
+    }
+    
+    .code-block {
+        background-color: #333333;
+        color: #FFFFFF;
+        border-radius: 3px;
+        padding: 2rem;
+        display: flex;
+        align-items: center;
+        font-weight: bold;
+        overflow: auto;
+    }
+</style>

--- a/scripts/front-end/components/screens/PreremplissageDerogation.svelte
+++ b/scripts/front-end/components/screens/PreremplissageDerogation.svelte
@@ -1,0 +1,11 @@
+<script>
+    import Squelette from '../Squelette.svelte'
+</script>
+
+<Squelette>
+    <div class="fr-grid-row fr-pt-6w fr-grid-row--center">
+        <div class="fr-col">
+            <h1>Pré-remplissage dérogation espèces protégées</h1>
+        </div>
+    </div>
+</Squelette>

--- a/scripts/front-end/main.js
+++ b/scripts/front-end/main.js
@@ -6,6 +6,7 @@ import Accueil from './routes/Accueil.js'
 import Dossier from './routes/Dossier.js';
 import SaisieEspèces from './routes/SaisieEspèces.js';
 import ImportHistoriqueNouvelleAquitaine from './routes/import-historique/NouvelleAquitaine.js'
+import PreremplissageDerogation from './routes/PreremplissageDerogation.js';
 
 import { init } from './actions/main.js';
 
@@ -13,6 +14,7 @@ page('/', Accueil)
 page('/dossier/:dossierId', Dossier)
 page('/saisie-especes', SaisieEspèces)
 page('/import-historique/nouvelle-aquitaine', ImportHistoriqueNouvelleAquitaine)
+page('/preremplissage-derogation', PreremplissageDerogation)
 
 init()
     .then(() => page.start())

--- a/scripts/front-end/routes/PreremplissageDerogation.js
+++ b/scripts/front-end/routes/PreremplissageDerogation.js
@@ -1,0 +1,29 @@
+//@ts-check
+
+import { replaceComponent } from '../routeComponentLifeCycle.js'
+import store from '../store.js'
+import { svelteTarget } from '../config.js'
+import { mapStateToSqueletteProps } from '../mapStateToComponentProps.js';
+
+import PreremplissageDerogation from '../components/screens/PreremplissageDerogation.svelte'
+
+export default () => {
+    /**
+     * 
+     * @param {import('../store.js').PitchouState} _ 
+     * @returns 
+     */
+    function mapStateToProps(){
+        return {
+            ...mapStateToSqueletteProps(store.state),
+        }
+    }   
+    
+    const preremplissageDerogation = new PreremplissageDerogation({
+        target: svelteTarget,
+        props: mapStateToProps(store.state)
+    });
+
+    replaceComponent(preremplissageDerogation, mapStateToProps)
+
+}

--- a/scripts/server/main.js
+++ b/scripts/server/main.js
@@ -38,7 +38,9 @@ fastify.get('/dossier/:dossierId', (request, reply) => {
 fastify.get('/import-historique/nouvelle-aquitaine', (request, reply) => {
   reply.sendFile('index.html')
 })
-
+fastify.get('/preremplissage-derogation', (request, reply) => {
+  reply.sendFile('index.html')
+})
 
 // Privileged routes
 fastify.get('/dossiers', async function (request, reply) {


### PR DESCRIPTION
## Description

Afin de permettre aux instructeurices de plus facilement créer des dossiers sur Démarches Simplifiées, on décide de créer une page sur Pitchou qui permet de fabriquer facilement un lien de pré-remplissage pour la dérogation espèces protégées.

- [x] Des `<select>` pour choisir l'option qu'on souhaite pour un champ donné
- [ ] utiliser et mettre à jour si nécessaire la méthode `créerLienPréremplissageDémarche` pour fabriquer le lien

## Aperçu
![Screenshot 2024-07-18 at 18-36-01 Pitchou](https://github.com/user-attachments/assets/753a2780-23a4-4fdf-867a-da373849a9e6)

