### PR TITLE
Ajout colonne `Soumis au régime AE` tableau suivi

### DIFF
--- a/cron.json
+++ b/cron.json
@@ -3,6 +3,10 @@
       {
         "command": "*/10 * * * * node outils/sync-démarches-simplifiées.js",
         "size": "S"
+      },
+      {
+        "command": "5 0 */1 * * node outils/sync-démarches-simplifiées.js --lastModified 2024-01-29",
+        "size": "S"
       }
     ]
 }

--- a/cron.json
+++ b/cron.json
@@ -5,7 +5,7 @@
         "size": "S"
       },
       {
-        "command": "5 0 */1 * * node outils/sync-démarches-simplifiées.js --lastModified 2024-01-29",
+        "command": "5 0 * * * node outils/sync-démarches-simplifiées.js --lastModified 2024-01-29",
         "size": "S"
       }
     ]

--- a/migrations/20240731192043_ajout-ae.js
+++ b/migrations/20240731192043_ajout-ae.js
@@ -4,7 +4,7 @@
  */
 export function up(knex) {
     return knex.schema.alterTable('dossier', (table) => {
-        table.boolean('soumis_au_regime_ae').defaultTo(false)
+        table.boolean('rattaché_au_régime_ae')
     });
 };
 
@@ -14,6 +14,6 @@ export function up(knex) {
  */
 export function down(knex) {
     return knex.schema.alterTable('dossier', (table) => {
-        table.dropColumn('soumis_au_regime_ae')
+        table.dropColumn('rattaché_au_régime_ae')
     });
 };

--- a/migrations/20240731192043_ajout-ae.js
+++ b/migrations/20240731192043_ajout-ae.js
@@ -1,0 +1,19 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export function up(knex) {
+    return knex.schema.alterTable('dossier', (table) => {
+        table.boolean('soumis_au_regime_ae').defaultTo(false)
+    });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export function down(knex) {
+    return knex.schema.alterTable('dossier', (table) => {
+        table.dropColumn('soumis_au_regime_ae')
+    });
+};

--- a/outils/sync-démarches-simplifiées.js
+++ b/outils/sync-démarches-simplifiées.js
@@ -84,7 +84,8 @@ const pitchouKeyToChampDS = {
     "communes": 'Q2hhbXAtNDA0MTQ0MQ==',
     "départements" : 'Q2hhbXAtNDA0MTQ0NQ==',
     "régions" : 'Q2hhbXAtNDA0MTQ0OA==',
-    "Le projet se situe au niveau…": 'Q2hhbXAtMzg5NzQwOA=='
+    "Le projet se situe au niveau…": 'Q2hhbXAtMzg5NzQwOA==',
+    "Le projet est-il soumis au régime de l'Autorisation Environnementale (article L. 181-1 du Code de l'environnement) ?" : "Q2hhbXAtNDA4MzAxMQ==",
 }
 
 /*
@@ -252,6 +253,8 @@ const dossiers = dossiersDS.map(({
         }
     }
 
+    /** Régime AE */
+    const soumis_au_regime_ae = champById.get(pitchouKeyToChampDS["Le projet est-il soumis au régime de l'Autorisation Environnementale (article L. 181-1 du Code de l'environnement) ?"]).checked
 
     /** 
      * Annotations privées 
@@ -325,6 +328,7 @@ const dossiers = dossiersDS.map(({
         communes: JSON.stringify(communes),
         départements: JSON.stringify(départements),
         régions: JSON.stringify(régions),
+        soumis_au_regime_ae,
 
         // annotations privées
         historique_nom_porteur,

--- a/outils/sync-démarches-simplifiées.js
+++ b/outils/sync-démarches-simplifiées.js
@@ -254,10 +254,10 @@ const dossiers = dossiersDS.map(({
     }
 
     /** Régime AE */
-    const soumis_au_regime_ae = champById.get(pitchouKeyToChampDS["Le projet est-il soumis au régime de l'Autorisation Environnementale (article L. 181-1 du Code de l'environnement) ?"]).checked
+    const rattaché_au_régime_ae = champById.get(pitchouKeyToChampDS["Le projet est-il soumis au régime de l'Autorisation Environnementale (article L. 181-1 du Code de l'environnement) ?"]).checked
 
-    /** 
-     * Annotations privées 
+    /**
+     * Annotations privées
      */
     /** @type {Map<string, any>} */
     const annotationById = new Map()
@@ -328,7 +328,7 @@ const dossiers = dossiersDS.map(({
         communes: JSON.stringify(communes),
         départements: JSON.stringify(départements),
         régions: JSON.stringify(régions),
-        soumis_au_regime_ae,
+        rattaché_au_régime_ae,
 
         // annotations privées
         historique_nom_porteur,

--- a/scripts/front-end/components/screens/SuiviInstruction.svelte
+++ b/scripts/front-end/components/screens/SuiviInstruction.svelte
@@ -28,11 +28,14 @@
                             <th>Porteur de projet</th>
                             <th>Nom du projet</th>
                             <th>Enjeux</th>
-                            <th>Soumis au régime AE</th>
+                            <th>Rattaché au régime AE</th>
                         </tr>
                     </thead>
                     <tbody>
-                        {#each dossiers as { id, nom_dossier, déposant_nom, déposant_prénoms, communes, départements, régions, enjeu_politique, enjeu_écologique, soumis_au_regime_ae }}
+                        {#each dossiers as { id, nom_dossier, déposant_nom,
+                          déposant_prénoms, communes, départements, régions,
+                          enjeu_politique, enjeu_écologique,
+                          rattaché_au_régime_ae }}
                             <tr>
                                 <td><a href={`/dossier/${id}`}>Voir le dossier</a></td>
                                 <td>{formatLocalisation({communes, départements, régions})}</td>
@@ -53,7 +56,7 @@
 
                                 </td>
                                 <td>
-                                    {soumis_au_regime_ae ? "oui" : "non"}
+                                    {rattaché_au_régime_ae ? "oui" : "non"}
                                 </td>
                             </tr>
                         {/each}

--- a/scripts/front-end/components/screens/SuiviInstruction.svelte
+++ b/scripts/front-end/components/screens/SuiviInstruction.svelte
@@ -1,7 +1,7 @@
 <script>
     //@ts-check
     import Squelette from '../Squelette.svelte'
-    import {formatLocalisation, formatDemandeur, formatDéposant, formatDateRelative, formatDateAbsolue} from '../../affichageDossier.js'
+    import {formatLocalisation, formatDéposant} from '../../affichageDossier.js'
 
     /** @import {DossierComplet} from '../../../types.js' */
 
@@ -28,10 +28,11 @@
                             <th>Porteur de projet</th>
                             <th>Nom du projet</th>
                             <th>Enjeux</th>
+                            <th>Soumis au régime AE</th>
                         </tr>
                     </thead>
                     <tbody>
-                        {#each dossiers as { id, nom_dossier, déposant_nom, déposant_prénoms, communes, départements, régions, enjeu_politique, enjeu_écologique }}
+                        {#each dossiers as { id, nom_dossier, déposant_nom, déposant_prénoms, communes, départements, régions, enjeu_politique, enjeu_écologique, soumis_au_regime_ae }}
                             <tr>
                                 <td><a href={`/dossier/${id}`}>Voir le dossier</a></td>
                                 <td>{formatLocalisation({communes, départements, régions})}</td>
@@ -51,6 +52,9 @@
                                     {/if}
 
                                 </td>
+                                <td>
+                                    {soumis_au_regime_ae ? "oui" : "non"}
+                                </td>
                             </tr>
                         {/each}
                     </tbody>
@@ -65,6 +69,10 @@
 <style lang="scss">
     td, th{
         vertical-align: top;
+    }
+
+    th {
+        min-width: 6rem;
     }
 
     .fr-badge {

--- a/scripts/server/database.js
+++ b/scripts/server/database.js
@@ -129,6 +129,7 @@ export function listAllDossiersComplets() {
             "date_dépôt",
             "dossier.nom as nom_dossier",
             "espèces_protégées_concernées", 
+            "soumis_au_regime_ae",
             
             // localisation
             "départements", 

--- a/scripts/server/database.js
+++ b/scripts/server/database.js
@@ -129,7 +129,7 @@ export function listAllDossiersComplets() {
             "date_dépôt",
             "dossier.nom as nom_dossier",
             "espèces_protégées_concernées", 
-            "soumis_au_regime_ae",
+            "rattaché_au_régime_ae",
             
             // localisation
             "départements", 

--- a/scripts/types/database/public/Dossier.js
+++ b/scripts/types/database/public/Dossier.js
@@ -43,6 +43,7 @@ export {};
  * @property {string | null} historique_référence_arrêté_ministériel
  * @property {boolean | null} enjeu_écologique
  * @property {string | null} commentaire_libre
+ * @property {boolean | null} rattaché_au_régime_ae
  */
 /**
  * Represents the initializer for the table public.dossier
@@ -82,6 +83,7 @@ export {};
  * @property {string | null} [historique_référence_arrêté_ministériel]
  * @property {boolean | null} [enjeu_écologique]
  * @property {string | null} [commentaire_libre]
+ * @property {boolean | null} [rattaché_au_régime_ae]
  */
 /**
  * Represents the mutator for the table public.dossier
@@ -121,4 +123,5 @@ export {};
  * @property {string | null} [historique_référence_arrêté_ministériel]
  * @property {boolean | null} [enjeu_écologique]
  * @property {string | null} [commentaire_libre]
+ * @property {boolean | null} [rattaché_au_régime_ae]
  */

--- a/scripts/types/database/public/Dossier.ts
+++ b/scripts/types/database/public/Dossier.ts
@@ -78,6 +78,8 @@ export default interface Dossier {
   enjeu_écologique: boolean | null;
 
   commentaire_libre: string | null;
+
+  soumis_au_regime_ae: boolean;
 }
 
 /** Represents the initializer for the table public.dossier */

--- a/scripts/types/database/public/Dossier.ts
+++ b/scripts/types/database/public/Dossier.ts
@@ -79,7 +79,7 @@ export default interface Dossier {
 
   commentaire_libre: string | null;
 
-  soumis_au_regime_ae: boolean;
+  rattaché_au_régime_ae: boolean | null;
 }
 
 /** Represents the initializer for the table public.dossier */
@@ -154,6 +154,8 @@ export interface DossierInitializer {
   enjeu_écologique?: boolean | null;
 
   commentaire_libre?: string | null;
+
+  rattaché_au_régime_ae: boolean | null;
 }
 
 /** Represents the mutator for the table public.dossier */
@@ -227,4 +229,6 @@ export interface DossierMutator {
   enjeu_écologique?: boolean | null;
 
   commentaire_libre?: string | null;
+
+  rattaché_au_régime_ae: boolean | null;
 }


### PR DESCRIPTION
cf. tâche Trello : https://trello.com/c/wCGlPJUY/138-%C3%A9volutions-tableau-dossier-pitchou

J'ai fait un micmac avec git et github. J'ai donc réouvert une PR. Les commentaires précédents sont sur https://github.com/betagouv/pitchou/pull/54.

## Description

Cette PR ajoute une colonne `Soumis au régime AE` dans le tableau de suivi, ainsi qu'un job une fois par jour (à 00:05) pour mettre à jour l'ensemble des dossiers avec DS