### PR TITLE
Amélioration des contraintes foreign de la table arête_personne__cap_écriture_annotation

### DIFF
--- a/migrations/20240918135633_on-update-code-acces.js
+++ b/migrations/20240918135633_on-update-code-acces.js
@@ -1,0 +1,36 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function up(knex) {
+
+    await knex.schema.alterTable('arête_personne__cap_écriture_annotation', function (table) {
+        table.dropForeign('personne_cap')
+        table.dropForeign('écriture_annotation_cap')
+
+        table.foreign('personne_cap')
+            .references('code_accès').inTable('personne').onUpdate('CASCADE').onDelete('CASCADE')
+        
+        table.foreign('écriture_annotation_cap')
+            .references('cap').inTable('cap_écriture_annotation').onUpdate('CASCADE').onDelete('CASCADE')
+    });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function down(knex) {
+    
+    await knex.schema.alterTable('arête_personne__cap_écriture_annotation', function (table) {
+        table.dropForeign('personne_cap')
+        table.dropForeign('écriture_annotation_cap')
+
+        table.foreign('personne_cap')
+            .references('code_accès').inTable('personne').onUpdate('NO ACTION').onDelete('NO ACTION')
+        
+        table.foreign('écriture_annotation_cap')
+            .references('cap').inTable('cap_écriture_annotation').onUpdate('NO ACTION').onDelete('NO ACTION')
+    });
+
+};


### PR DESCRIPTION
En essayant de re-générer un code_accès par email, la base de donnée refusait de modifier le code_accès, parce que ça transgressait la contrainte `foreign` de `arête_personne__cap_écriture_annotation.personne_cap`

Cette PR rajoute surtout un `.onUpdate('CASCADE')` à cette colonne pour que quand le code change, la colonne `arête_personne__cap_écriture_annotation.personne_cap` est modifiée avec la nouvelle valeur