### PR TITLE
Fix le copier-coller sur la page saisie des espèces

### DIFF
--- a/scripts/front-end/components/SaisieEspèces/FieldsetFlore.svelte
+++ b/scripts/front-end/components/SaisieEspèces/FieldsetFlore.svelte
@@ -78,7 +78,7 @@
                                 </td>
                                 <td>
                                     <select bind:value={activité} class="fr-select">
-                                        <option>-</option>
+                                        <option value="{undefined}">-</option>
                                         {#each activitésMenaçantes || [] as act}
                                         <option value={act}>
                                             {act['étiquette affichée']}
@@ -89,7 +89,7 @@
 
                                 <td>
                                     <select bind:value={nombreIndividus} class="fr-select">
-                                        <option>-</option>
+                                        <option value="{undefined}">-</option>
                                         {#each fourchettesIndividus as fourchette}
                                             <option value={fourchette}>{fourchette}</option>
                                         {/each}

--- a/scripts/front-end/components/SaisieEspèces/FieldsetNonOiseau.svelte
+++ b/scripts/front-end/components/SaisieEspèces/FieldsetNonOiseau.svelte
@@ -86,7 +86,7 @@
                                 </td>
                                 <td>
                                     <select bind:value={activité} class="fr-select">
-                                        <option>-</option>
+                                        <option value="{undefined}">-</option>
                                         {#each activitésMenaçantes || [] as act}
                                         <option value={act}>
                                             {act['étiquette affichée']}
@@ -97,7 +97,7 @@
 
                                 <td>
                                     <select bind:value={méthode} disabled={activité && activité['Méthode'] === 'n'} class="fr-select">
-                                        <option>-</option>
+                                        <option value="{undefined}">-</option>
                                         {#each méthodesMenaçantes as met}
                                             <option value={met}>{met['étiquette affichée']}</option>
                                         {/each}
@@ -106,7 +106,7 @@
 
                                 <td>
                                     <select bind:value={transport} disabled={activité && activité['transport'] === 'n'} class="fr-select">
-                                        <option>-</option>
+                                        <option value="{undefined}">-</option>
                                         {#each transportMenaçants as trans}
                                             <option value={trans}>{trans['étiquette affichée']}</option>
                                         {/each}
@@ -115,7 +115,7 @@
 
                                 <td>
                                     <select bind:value={nombreIndividus} class="fr-select">
-                                        <option>-</option>
+                                        <option value="{undefined}">-</option>
                                         {#each fourchettesIndividus as fourchette}
                                             <option value={fourchette}>{fourchette}</option>
                                         {/each}

--- a/scripts/front-end/components/SaisieEspèces/FieldsetOiseau.svelte
+++ b/scripts/front-end/components/SaisieEspèces/FieldsetOiseau.svelte
@@ -87,7 +87,7 @@
                                 </td>
                                 <td>
                                     <select bind:value={activité} class="fr-select">
-                                        <option>-</option>
+                                        <option value="{undefined}">-</option>
                                         {#each activitésMenaçantes || [] as act}
                                         <option value={act}>
                                             {act['étiquette affichée']}
@@ -98,7 +98,7 @@
 
                                 <td>
                                     <select bind:value={méthode} disabled={activité && activité['Méthode'] === 'n'} class="fr-select">
-                                        <option>-</option>
+                                        <option value="{undefined}">-</option>
                                         {#each méthodesMenaçantes as met}
                                             <option value={met}>{met['étiquette affichée']}</option>
                                         {/each}
@@ -107,7 +107,7 @@
 
                                 <td>
                                     <select bind:value={transport} disabled={activité && activité['transport'] === 'n'} class="fr-select">
-                                        <option>-</option>
+                                        <option value="{undefined}">-</option>
                                         {#each transportMenaçants as trans}
                                             <option value={trans}>{trans['étiquette affichée']}</option>
                                         {/each}
@@ -116,7 +116,7 @@
 
                                 <td>
                                     <select bind:value={nombreIndividus} class="fr-select">
-                                        <option>-</option>
+                                        <option value="{undefined}">-</option>
                                         {#each fourchettesIndividus as fourchette}
                                             <option value={fourchette}>{fourchette}</option>
                                         {/each}


### PR DESCRIPTION
cf. carte trello : https://trello.com/c/s8srKdoN/246-voir-le-bug-de-copier-coller-du-lien-des-esp%C3%A8ces

Le copier-coller ne fonctionne pas car l'utilisation des typeguards sur les types `FauneNonOiseauAtteinte`, `OiseauAtteint` et `FloreAtteinte` jette une erreur. En effet, sur la page de saisie des espèces, on bind des valeurs `string` sur des propriétés de ces types qui sont soit des `object`, soit `undefined`. 

Sur les types `FauneNonOiseauAtteinte`, `OiseauAtteint` et `FloreAtteinte`, à part l'`espèce`, toutes les propriétés sont optionnelles. J'ai donc choisi de binder `undefined` sur les `select` pour fixer tout ça.