### PR TITLE
Retire les `dispatch` dans les composants Svelte

### DIFF
--- a/scripts/front-end/components/BarreRecherche.svelte
+++ b/scripts/front-end/components/BarreRecherche.svelte
@@ -1,14 +1,13 @@
 <script>
     //@ts-check
 
-    import { createEventDispatcher } from "svelte";
-
     /** @type {string} */
     export let titre
 
-    let valeur = ""
+    /** @type {function}*/
+    export let mettreÀJourTexteRecherche
 
-    const dispatch = createEventDispatcher()
+    let valeur = ""
     
     /**
      * 
@@ -16,7 +15,7 @@
      */
     function onMettreÀJourValeurSélectionnée(e) {
         e.preventDefault()
-        dispatch("selected-changed", valeur)
+        mettreÀJourTexteRecherche(valeur)
         valeur = ""
     }
 </script>

--- a/scripts/front-end/components/FiltreParmiOptions.svelte
+++ b/scripts/front-end/components/FiltreParmiOptions.svelte
@@ -1,16 +1,16 @@
 <script>
     //@ts-check
 
-    import { createEventDispatcher } from "svelte";
-
     /** @type {Set<string>}*/
     export let options  
 
     /** @type {string} */
     export let titre
 
+    /** @type {function} */
+    export let mettreÀJourOptionsSélectionnées
+
     let optionsSélectionnées = new Set(options)
-    const dispatch = createEventDispatcher()
 
     $: optionsAffichées = [...options].map(option => ({option, checked: optionsSélectionnées.has(option)}))
 
@@ -31,19 +31,18 @@
         }
 
         rerender()
-        dispatch("selected-changed", optionsSélectionnées)
+        mettreÀJourOptionsSélectionnées(optionsSélectionnées)
     }
 
     function selectionnerTout(){
         optionsSélectionnées = new Set(options)
-        dispatch("selected-changed", optionsSélectionnées)
+        mettreÀJourOptionsSélectionnées(optionsSélectionnées)
     }
 
 
     function selectionnerRien(){
         optionsSélectionnées = new Set()
-        dispatch("selected-changed", optionsSélectionnées)
-
+        mettreÀJourOptionsSélectionnées(optionsSélectionnées)
     }
 
 

--- a/scripts/front-end/components/SaisieEspèces/FieldsetFlore.svelte
+++ b/scripts/front-end/components/SaisieEspèces/FieldsetFlore.svelte
@@ -126,11 +126,6 @@
             text-align: center;
             vertical-align: middle;
         }
-
-        button{
-            all: unset;
-            cursor: pointer;
-        }
         
         input[type="number"] {
             border-radius: 0.5em;
@@ -163,11 +158,6 @@
                     padding: 0.2rem;
 
                     vertical-align: top;
-                }
-
-                button{
-                    all: unset;
-                    cursor: pointer;
                 }
             }
         }

--- a/scripts/front-end/components/screens/SuiviInstruction.svelte
+++ b/scripts/front-end/components/screens/SuiviInstruction.svelte
@@ -67,9 +67,9 @@
 
     /**
      * 
-     * @param {{detail: Set<DossierPhase | PHASE_VIDE>}} _
+     * @param {Set<DossierPhase | PHASE_VIDE>} phasesSélectionnées
      */
-	function filtrerParPhase({detail: phasesSélectionnées}){
+	function filtrerParPhase(phasesSélectionnées){
         tousLesFiltres.set('phase', dossier => {
             if (phasesSélectionnées.has(PHASE_VIDE)) {
                 return !dossier.phase
@@ -93,9 +93,9 @@
 
     /**
      * 
-     * @param {{detail: Set<DossierProchaineActionAttenduePar | PROCHAINE_ACTION_ATTENDUE_PAR_VIDE>}} _
+     * @param {Set<DossierProchaineActionAttenduePar | PROCHAINE_ACTION_ATTENDUE_PAR_VIDE>} prochainesActionsAttenduesParSélectionnées
      */
-    function filtrerParProchainesActionsAttenduesPar({detail: prochainesActionsAttenduesParSélectionnées}) {
+    function filtrerParProchainesActionsAttenduesPar(prochainesActionsAttenduesParSélectionnées) {
         tousLesFiltres.set("prochaine action attendue de", dossier => {
             if (prochainesActionsAttenduesParSélectionnées.has(PROCHAINE_ACTION_ATTENDUE_PAR_VIDE)) {
                 return !dossier.prochaine_action_attendue_par
@@ -178,9 +178,9 @@
 
     /**
      * 
-     * @param {{detail: Set<NonNullable<Personne['email']> | AUCUN_INSTRUCTEUR>}} _
+     * @param {Set<NonNullable<Personne['email']> | AUCUN_INSTRUCTEUR>} _instructeursSélectionnées
      */
-	function filtrerParInstructeurs({detail: _instructeursSélectionnées}){
+	function filtrerParInstructeurs(_instructeursSélectionnées){
         tousLesFiltres.set('instructeurs', dossier => {
             if(!relationSuivis)
                 return true;
@@ -236,18 +236,18 @@
                     <FiltreParmiOptions 
                         titre="Filtrer par phase"
                         options={phaseOptions} 
-                        on:selected-changed={filtrerParPhase} 
+                        mettreÀJourOptionsSélectionnées={filtrerParPhase} 
                     />
                     <FiltreParmiOptions 
                         titre="Filtrer par prochaine action attendue par"
                         options={prochainesActionsAttenduesParOptions} 
-                        on:selected-changed={filtrerParProchainesActionsAttenduesPar} 
+                        mettreÀJourOptionsSélectionnées={filtrerParProchainesActionsAttenduesPar} 
                     />
                     {#if instructeursOptions && instructeursOptions.size >= 2}
                     <FiltreParmiOptions 
                         titre="Filtrer par instructeur suivant le dossier"
                         options={instructeursOptions} 
-                        on:selected-changed={filtrerParInstructeurs} 
+                        mettreÀJourOptionsSélectionnées={filtrerParInstructeurs} 
                     />
                     {/if}
                     {#if dossiersIdSuivisParInstructeurActuel && dossiersIdSuivisParInstructeurActuel.size >= 1}

--- a/scripts/front-end/components/screens/SuiviInstruction.svelte
+++ b/scripts/front-end/components/screens/SuiviInstruction.svelte
@@ -113,9 +113,9 @@
     $: texteÀChercher = ''
 
     /**
-     * @param {{detail: string}} _
+     * @param {string} _texteÀChercher
      */
-    function filtrerParTexte({detail: _texteÀChercher}){
+    function filtrerParTexte(_texteÀChercher) {
         // cf. https://github.com/MihaiValentin/lunr-languages/issues/66
         // lunr.fr n'indexe pas les chiffres. On gère donc la recherche sur 
         // les nombres avec une fonction séparée.
@@ -229,7 +229,7 @@
             {#if dossiers.length >= 1}
                 <BarreRecherche
                     titre="Rechercher par texte libre"
-                    on:selected-changed={filtrerParTexte}
+                    mettreÀJourTexteRecherche={filtrerParTexte}
                 />
 
                 <div class="filtres">


### PR DESCRIPTION
cf. https://github.com/betagouv/pitchou/pull/103#discussion_r1828904411

Mini PR de follow-up par rapport à ce [commentaire](https://github.com/betagouv/pitchou/pull/103#discussion_r1828904411). Je retire les appels à `dispatch` pour la future migration à Svelte 5.