### PR TITLE
Création d'un container pour du tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,9 @@ Sinon, on peut suivre la [procédure de la documentation Scalingo](https://doc.s
 
 `knex migrate:latest` (fait automatiquement à chaque déploiement, voir package.json `scripts.prestart:prod-server`)
 
-Pour revenir en arrière sur une migration : `knex migrate:down --env docker_dev`
+Pour aller en arrière et en avant d'un cran dans la liste des migrations : 
+`npm run migrate:down`
+`npm run migrate:up`
 
 ### Fabriquer la liste des espèces protégées
 
@@ -132,12 +134,12 @@ Puis lancer `node outils/liste-espèces.js` pour régénérer une liste d'espèc
 
 En dev, depuis le container du serveur
 
-`docker exec node_server node --env-file=.env outils/sync-démarches-simplifiées-88444.js` (dernières heures par défaut)
+`docker exec tooling node --env-file=.env outils/sync-démarches-simplifiées-88444.js` (dernières heures par défaut)
 
-`docker exec node_server node --env-file=.env outils/sync-démarches-simplifiées-88444.js --lastModified 2024-07-25` (synchroniser les dossiers modifiés depuis le 25 juillet 2024)
+`docker exec tooling node --env-file=.env outils/sync-démarches-simplifiées-88444.js --lastModified 2024-07-25` (synchroniser les dossiers modifiés depuis le 25 juillet 2024)
 
 
-`docker exec node_server node --env-file=.env outils/sync-démarches-simplifiées-88444.js --lastModified 2024-01-01` (synchroniser tous les dossiers, date très distantes)
+`docker exec tooling node --env-file=.env outils/sync-démarches-simplifiées-88444.js --lastModified 2024-01-01` (synchroniser tous les dossiers, date très distantes)
 
 ### Cron
 
@@ -156,13 +158,13 @@ Pour modifier le cron : https://crontab.guru/
 
 Utile pour tester rapidement en local après un restore de backup en tant qu'une personne en particulier
 
-`docker exec node_server node outils/afficher-liens-de-connexion.js --emails adresse1@e.mail,adresse2@e.mail`
+`docker exec tooling node outils/afficher-liens-de-connexion.js --emails adresse1@e.mail,adresse2@e.mail`
 
 Pour les lien de connexion en production : 
 
-`docker exec node_server node outils/afficher-liens-de-connexion.js --emails adresse1@e.mail,adresse2@e.mail --prod`
+`docker exec tooling node outils/afficher-liens-de-connexion.js --emails adresse1@e.mail,adresse2@e.mail --prod`
 
 Pour donner l'origine de manière libre :
 
-`docker exec node_server node outils/afficher-liens-de-connexion.js --emails adresse1@e.mail,adresse2@e.mail --origin 'http://test.lol'`
+`docker exec tooling node outils/afficher-liens-de-connexion.js --emails adresse1@e.mail,adresse2@e.mail --origin 'http://test.lol'`
 

--- a/compose.yml
+++ b/compose.yml
@@ -17,6 +17,20 @@ services:
     user: "${UID}:${GID}"
     stop_grace_period: 2s
 
+  tooling:
+    image: node:20
+    container_name: tooling
+    depends_on:
+      - db
+    volumes:
+      - ./:/app
+    working_dir: /app
+    command: sleep 365d
+    environment:
+      DATABASE_URL: "postgresql://dev:dev_password@postgres_db:5432/principale"
+    user: "${UID}:${GID}"
+    stop_grace_period: 1s
+
   db:
     image: postgres:15.7
     container_name: postgres_db

--- a/package.json
+++ b/package.json
@@ -15,10 +15,10 @@
     "prestart:prod-server": "knex migrate:latest",
     "start:prod-server": "node scripts/server/main.js",
     "build-types": "npm-run-all --parallel build-types:*",
-    "build-types:db": "docker exec node_server npx kanel -d postgresql://dev:dev_password@postgres_db:5432/principale -o ./scripts/types/database && ts-to-jsdoc --force ./scripts/types/database/public/*.ts",
+    "build-types:db": "docker exec tooling npx kanel -d postgresql://dev:dev_password@postgres_db:5432/principale -o ./scripts/types/database && ts-to-jsdoc --force ./scripts/types/database/public/*.ts",
     "build-types:ds-88444": "node outils/genere-types-88444.js",
-    "migrate:up": "docker exec node_server npx knex migrate:up --env docker_dev",
-    "migrate:down": "docker exec node_server npx knex migrate:down --env docker_dev"
+    "migrate:up": "docker exec tooling npx knex migrate:up --env docker_dev",
+    "migrate:down": "docker exec tooling npx knex migrate:down --env docker_dev"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^25.0.7",


### PR DESCRIPTION
Ça permet de pouvoir lancer des commandes de maintenance indépendammant de si le serveur se lance ou pas (indépendamment de si des migrations échouent, etc.)