### PR TITLE
Normalisation nom base de données pour simplifier les restore

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Cela va dévoiler un fichier `.pgsql` du même nom
 Ensuite :
 
 ```sh
-docker exec postgres_db pg_restore --create --clean --username=dev --no-owner --jobs=6 /var/lib/pitchou/backups/<nom_fichier>.pgsql
+docker exec postgres_db pg_restore --clean --if-exists --dbname=especes_pro_3731 --username=dev --no-owner --jobs=6 /var/lib/pitchou/backups/<nom_fichier>.pgsql
 ```
 
 ##### Restorer un backup en prod

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Cela va dévoiler un fichier `.pgsql` du même nom
 Ensuite :
 
 ```sh
-docker exec postgres_db pg_restore -C --username=dev -d principale --clean --no-owner --jobs=6 /var/lib/pitchou/backups/<nom_fichier>.pgsql
+docker exec postgres_db pg_restore --create --clean --username=dev --no-owner --jobs=6 /var/lib/pitchou/backups/<nom_fichier>.pgsql
 ```
 
 ##### Restorer un backup en prod

--- a/compose.yml
+++ b/compose.yml
@@ -13,7 +13,7 @@ services:
     command: npm run start:server
     environment:
       PORT: 2648
-      DATABASE_URL: "postgresql://dev:dev_password@postgres_db:5432/principale"
+      DATABASE_URL: "postgresql://dev:dev_password@postgres_db:5432/especes_pro_3731"
     user: "${UID}:${GID}"
     stop_grace_period: 2s
 
@@ -27,7 +27,7 @@ services:
     working_dir: /app
     command: sleep 365d
     environment:
-      DATABASE_URL: "postgresql://dev:dev_password@postgres_db:5432/principale"
+      DATABASE_URL: "postgresql://dev:dev_password@postgres_db:5432/especes_pro_3731"
     user: "${UID}:${GID}"
     stop_grace_period: 1s
 
@@ -38,7 +38,7 @@ services:
     environment:
       POSTGRES_USER: dev
       POSTGRES_PASSWORD: dev_password
-      POSTGRES_DB: principale
+      POSTGRES_DB: especes_pro_3731
     hostname: localhost
     ports:
       - "5432:5432"

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "prestart:prod-server": "knex migrate:latest",
     "start:prod-server": "node scripts/server/main.js",
     "build-types": "npm-run-all --parallel build-types:*",
-    "build-types:db": "docker exec tooling npx kanel -d postgresql://dev:dev_password@postgres_db:5432/principale -o ./scripts/types/database",
+    "build-types:db": "docker exec tooling npx kanel -d postgresql://dev:dev_password@postgres_db:5432/especes_pro_3731 -o ./scripts/types/database",
     "build-types:ds-88444": "node outils/genere-types-88444.js",
     "migrate:up": "docker exec tooling npx knex migrate:up --env docker_dev",
     "migrate:down": "docker exec tooling npx knex migrate:down --env docker_dev"


### PR DESCRIPTION
... bon, c'était pas ce sur quoi je bossais, mais ça a eu lieu comme ça...

j'ai eu un problème de BDD sur ma machine
Les restore échouaient, donc, j'ai travaillé à une procédure de restore fiable

Ça m'a demandé de nommer la BDD en dev comme celle en prod

@Ynote J'imagine que si tu merges, tu vas perdre le contact vers tes données (vu que le nom de la BDD a changé), donc le test ici, c'est de refaire un restore et vérifier que ce qui s'affiche chez toi est à peu près la même chose que la prod

et vu qu'on n'a pas vraiment changé quoi que ce soit de notre côté, j'imagine que c'est des différences dans le format de dump de Scalingo