### PR TITLE
Tri par phase et prochaine action attendue par

### DIFF
--- a/migrations/20250110101538_drop-null-date-depot.js
+++ b/migrations/20250110101538_drop-null-date-depot.js
@@ -1,0 +1,23 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function up(knex) {
+
+    await knex.schema.alterTable('dossier', table => {
+        // un dossier doit toujours avoir une date de dépôt
+        table.dropNullable('date_dépôt')
+    })
+
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function down(knex) {
+    await knex.schema.alterTable('dossier', table => {
+        table.setNullable('date_dépôt')
+    })
+};
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "csv-parse": "^5.5.6",
         "csv-stringify": "^6.5.0",
         "d3-fetch": "^3.0.1",
-        "date-fns": "^3.6.0",
+        "date-fns": "^4.1.0",
         "fastify": "^4.26.2",
         "knex": "^3.1.0",
         "ky": "^1.7.2",
@@ -1277,9 +1277,10 @@
       }
     },
     "node_modules/date-fns": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
-      "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@fastify/static": "^7.0.1",
         "@gouvfr/dsfr": "^1.11.2",
         "baredux": "github:DavidBruant/baredux#v1.0.8",
+        "clsx": "^2.1.1",
         "csv-parse": "^5.5.6",
         "csv-stringify": "^6.5.0",
         "d3-fetch": "^3.0.1",
@@ -1032,6 +1033,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/code-red": {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@fastify/static": "^7.0.1",
     "@gouvfr/dsfr": "^1.11.2",
     "baredux": "github:DavidBruant/baredux#v1.0.8",
+    "clsx": "^2.1.1",
     "csv-parse": "^5.5.6",
     "csv-stringify": "^6.5.0",
     "d3-fetch": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "csv-parse": "^5.5.6",
     "csv-stringify": "^6.5.0",
     "d3-fetch": "^3.0.1",
-    "date-fns": "^3.6.0",
+    "date-fns": "^4.1.0",
     "fastify": "^4.26.2",
     "knex": "^3.1.0",
     "ky": "^1.7.2",

--- a/scripts/front-end/actions/main.js
+++ b/scripts/front-end/actions/main.js
@@ -44,6 +44,12 @@ export function chargerDossiers(){
                     throw new TypeError("On attendait un tableau de dossiers ici !")
                 }
 
+                /* Formatter les dossiers */
+                for(const dossier of dossiers){
+                    dossier.date_dépôt = new Date(dossier.date_dépôt)
+                }
+
+
                 /** @type {PitchouState['dossiers']} */
                 const dossiersById = new Map()
 

--- a/scripts/front-end/components/IndicateurDélai.svelte
+++ b/scripts/front-end/components/IndicateurDélai.svelte
@@ -1,0 +1,94 @@
+<script>
+    import clsx from 'clsx'
+
+    /** @type { 'info' | 'succès' | 'avertissement' | 'erreur' } */
+    export let style = 'info';
+
+    /** @type { number } */
+    export let quantité
+
+    /** @type { string } */
+    export let alt;
+
+    $: quantitéAjustée = quantité
+    $: {
+        if(quantitéAjustée < 0){
+            quantitéAjustée = 0
+        }
+        else{
+            if(quantitéAjustée > 5){
+                quantitéAjustée = 5
+            }
+        }
+
+        // arrondir à la demie-valeur la plus proche
+        quantitéAjustée = Math.round(quantitéAjustée*2)/2
+    }
+    
+    $: baseClasses = [
+        'trait',
+        style
+    ]
+    
+    $: traitsClasses = [...Array(Math.ceil(quantitéAjustée))].map((_, i) => {
+        if(quantitéAjustée - i >= 1){
+            return baseClasses
+        }
+        else{
+            return [
+                ...baseClasses,
+                'moitié'
+            ]
+        }
+    })
+
+</script>
+
+<div class="délai" title={alt}>
+    {#each traitsClasses as classes}
+        <span class={clsx(classes)}></span>
+    {/each}
+</div>
+
+
+<style lang="scss">
+    $largeur-trait: 1.5rem;
+
+    .délai{
+        height: 1rem;
+        display: flex;
+        flex-direction: row;
+        align-items: center;
+        justify-content: flex-start;
+
+        .trait{
+            width: $largeur-trait;
+            height: 50%;
+            transform: translateY(50%);
+
+            border: none;
+            border-top: 2px solid var(--border-default-grey);
+            margin-right: 0.2rem;
+
+            &.moitié{
+                width: calc($largeur-trait/2);
+            }
+
+            &.info{
+                border-color: var(--border-plain-info)
+            }
+            &.succès{
+                border-color: var(--border-plain-success)
+            }
+            &.avertissement{
+                border-color: var(--border-plain-warning)
+            }
+            &.erreur{
+                border-color: var(--border-plain-error)
+            }
+
+
+
+        }
+    }
+</style>

--- a/scripts/front-end/components/IndicateurDélaiPhase.svelte
+++ b/scripts/front-end/components/IndicateurDélaiPhase.svelte
@@ -1,0 +1,37 @@
+<script>
+    import { differenceInMonths, differenceInWeeks, addMonths, format } from 'date-fns';
+    import IndicateurDélai from './IndicateurDélai.svelte';
+    import {getDébutPhaseActuelle} from '../getDébutPhaseActuelle.js';
+
+    /** @import {DossierComplet} from '../../types/API_Pitchou.js' */
+    /** @import {default as ÉvènementPhaseDossier} from '../../types/database/public/ÉvènementPhaseDossier.js' */
+
+    /** @type { DossierComplet & {évènementsPhase: ÉvènementPhaseDossier[]} } */
+    export let dossier;
+
+    $: débutPhaseActuelle = getDébutPhaseActuelle(dossier)
+    $: monthDiff = differenceInMonths(new Date(), débutPhaseActuelle.dateDébut)
+    //$: console.log('monthDiff', monthDiff)
+    // le +1, c'est pour avoir un délai pessimiste
+    $: weekDiff = differenceInWeeks(new Date(), addMonths(débutPhaseActuelle.dateDébut, monthDiff)) + 1
+    // $: console.log('weekDiff', weekDiff)
+
+    $: quantité = monthDiff + (weekDiff/4)
+    $: alt = `depuis ${format(débutPhaseActuelle.dateDébut, 'yyyy-MM-dd')} - ~${monthDiff} mois`
+
+
+</script>
+
+{#if débutPhaseActuelle.phase === 'Instruction'}
+    <IndicateurDélai 
+        {quantité}
+        style={quantité >= 3 ? 'erreur' : (quantité >= 2 ? 'avertissement' : 'info') }
+        {alt}>
+    </IndicateurDélai>
+{:else}
+    <IndicateurDélai 
+        {quantité}
+        style='info' 
+        {alt}>
+    </IndicateurDélai>
+{/if}

--- a/scripts/front-end/components/SaisieEspèces/FieldsetFlore.svelte
+++ b/scripts/front-end/components/SaisieEspèces/FieldsetFlore.svelte
@@ -88,7 +88,7 @@
     }
 
     const trisImpacts = new Set([
-        { nom: "Grouper par impact", tri: trierParImpacts },
+        { nom: "Grouper", tri: trierParImpacts },
     ])
 </script>
 

--- a/scripts/front-end/components/SaisieEspèces/FieldsetFlore.svelte
+++ b/scripts/front-end/components/SaisieEspèces/FieldsetFlore.svelte
@@ -8,7 +8,7 @@
      } from "../../triEspèces.js"
     import AutocompleteEspeces from "../AutocompleteEspèces.svelte"
     import FloreAtteinteEditRow from "./FloreAtteinteEditRow.svelte"
-    import EnteteAvecTri from "../EnteteAvecTri.svelte"
+    import TrisDeTh from "../TrisDeTh.svelte"
 
     /** @import {FloreAtteinte, EspèceProtégée, ActivitéMenançante} from "../../../types/especes.d.ts" */
 
@@ -101,15 +101,15 @@
                     <thead>
                         <tr>
                             <th>
-                                <EnteteAvecTri
-                                    label="Espèce"
+                                Espèce
+                                <TrisDeTh
                                     tris={trisEspèces}
                                     bind:triSélectionné
                                 />
                             </th>
                             <th>
-                                <EnteteAvecTri
-                                    label="Type d'impact"
+                                Type d'impact
+                                <TrisDeTh
                                     tris={trisImpacts}
                                     bind:triSélectionné
                                 />

--- a/scripts/front-end/components/SaisieEspèces/FieldsetFlore.svelte
+++ b/scripts/front-end/components/SaisieEspèces/FieldsetFlore.svelte
@@ -201,8 +201,6 @@
 
             tr {
                 th{
-                    padding: 0.2rem;
-
                     vertical-align: top;
                 }
             }

--- a/scripts/front-end/components/SaisieEspèces/FieldsetFlore.svelte
+++ b/scripts/front-end/components/SaisieEspèces/FieldsetFlore.svelte
@@ -199,10 +199,8 @@
             // surcharge DSFR pour que l'autocomplete s'affiche correctement
             overflow: initial;
 
-            tr {
-                th{
-                    vertical-align: top;
-                }
+            tr th {
+                vertical-align: top;
             }
         }
     }

--- a/scripts/front-end/components/SaisieEspèces/FieldsetNonOiseau.svelte
+++ b/scripts/front-end/components/SaisieEspèces/FieldsetNonOiseau.svelte
@@ -95,7 +95,7 @@
     }
 
     const trisImpacts = new Set([
-        { nom: "Grouper par impact", tri: trierParImpacts },
+        { nom: "Grouper", tri: trierParImpacts },
     ])
 
     function trierParMéthode() {
@@ -104,7 +104,7 @@
     }
 
     const trisMéthodes = new Set([
-        { nom: "Grouper par méthode", tri: trierParMéthode },
+        { nom: "Grouper", tri: trierParMéthode },
     ])
 </script>
 
@@ -226,7 +226,7 @@
         table{
             // surcharge DSFR pour que l'autocomplete s'affiche correctement
             overflow: initial;
-            
+
             tr th {
                 vertical-align: top;
             }

--- a/scripts/front-end/components/SaisieEspèces/FieldsetNonOiseau.svelte
+++ b/scripts/front-end/components/SaisieEspèces/FieldsetNonOiseau.svelte
@@ -9,7 +9,7 @@
      } from "../../triEspèces.js"
     import AutocompleteEspeces from "../AutocompleteEspèces.svelte"
     import FauneNonOiseauAtteinteEditRow from "./FauneNonOiseauAtteinteEditRow.svelte"
-    import EnteteAvecTri from "../EnteteAvecTri.svelte"
+    import TrisDeTh from "../TrisDeTh.svelte"
 
     /** @import {FauneNonOiseauAtteinte, EspèceProtégée, ActivitéMenançante, MéthodeMenançante, TransportMenançant} from "../../../types/especes.d.ts" */
 
@@ -117,22 +117,22 @@
                     <thead>
                         <tr>
                             <th>
-                                <EnteteAvecTri
-                                    label="Espèce"
+                                Espèce
+                                <TrisDeTh
                                     tris={trisEspèces}
                                     bind:triSélectionné
                                 />
                             </th>
                             <th>
-                                <EnteteAvecTri
-                                    label="Type d'impact"
+                                Type d'impact
+                                <TrisDeTh
                                     tris={trisImpacts}
                                     bind:triSélectionné
                                 />
                             </th>
                             <th>
-                                <EnteteAvecTri
-                                    label="Méthode"
+                                Méthode
+                                <TrisDeTh
                                     tris={trisMéthodes}
                                     bind:triSélectionné
                                 />

--- a/scripts/front-end/components/SaisieEspèces/FieldsetNonOiseau.svelte
+++ b/scripts/front-end/components/SaisieEspèces/FieldsetNonOiseau.svelte
@@ -226,6 +226,10 @@
         table{
             // surcharge DSFR pour que l'autocomplete s'affiche correctement
             overflow: initial;
+            
+            tr th {
+                vertical-align: top;
+            }
         }
     }
 </style>

--- a/scripts/front-end/components/SaisieEspèces/FieldsetOiseau.svelte
+++ b/scripts/front-end/components/SaisieEspèces/FieldsetOiseau.svelte
@@ -231,6 +231,10 @@
         table{
             // surcharge DSFR pour que l'autocomplete s'affiche correctement
             overflow: initial;
+            
+            tr th {
+                vertical-align: top;
+            }
         }
     }
 </style>

--- a/scripts/front-end/components/SaisieEspèces/FieldsetOiseau.svelte
+++ b/scripts/front-end/components/SaisieEspèces/FieldsetOiseau.svelte
@@ -9,7 +9,7 @@
      } from "../../triEspèces.js"
     import AutocompleteEspeces from "../AutocompleteEspèces.svelte"
     import OiseauAtteintEditRow from "./OiseauAtteintEditRow.svelte"
-    import EnteteAvecTri from "../EnteteAvecTri.svelte"
+    import TrisDeTh from "../TrisDeTh.svelte"
 
     /** @import {OiseauAtteint, EspèceProtégée, ActivitéMenançante, MéthodeMenançante, TransportMenançant} from "../../../types/especes.d.ts" */
 
@@ -116,23 +116,23 @@
                 <table>
                     <thead>
                         <tr>
-                            <th class="flex">
-                                <EnteteAvecTri
-                                    label="Espèce"
+                            <th>
+                                Espèce
+                                <TrisDeTh
                                     tris={trisEspèces}
                                     bind:triSélectionné
                                 />
                             </th>
                             <th>
-                                <EnteteAvecTri
-                                    label="Type d'impact"
+                                Type d'impact
+                                <TrisDeTh
                                     tris={trisImpacts}
                                     bind:triSélectionné
                                 />
                             </th>
                             <th>
-                                <EnteteAvecTri
-                                    label="Méthode"
+                                Méthode
+                                <TrisDeTh
                                     tris={trisMéthodes}
                                     bind:triSélectionné
                                 />

--- a/scripts/front-end/components/SaisieEspèces/FieldsetOiseau.svelte
+++ b/scripts/front-end/components/SaisieEspèces/FieldsetOiseau.svelte
@@ -95,7 +95,7 @@
     }
 
     const trisImpacts = new Set([
-        { nom: "Grouper par impact", tri: trierParImpacts }
+        { nom: "Grouper", tri: trierParImpacts }
     ])
 
     function trierParMéthode() {
@@ -104,7 +104,7 @@
     }
 
     const trisMéthodes = new Set([
-        { nom: "Grouper par méthode", tri: trierParMéthode}
+        { nom: "Grouper", tri: trierParMéthode}
     ])
 </script>
 
@@ -231,7 +231,7 @@
         table{
             // surcharge DSFR pour que l'autocomplete s'affiche correctement
             overflow: initial;
-            
+
             tr th {
                 vertical-align: top;
             }

--- a/scripts/front-end/components/TrisDeTh.svelte
+++ b/scripts/front-end/components/TrisDeTh.svelte
@@ -1,9 +1,6 @@
 <script>
     // @ts-check
 
-    /** @type {string} */
-    export let label
-
     /** @type {Set<{nom: string, tri: function}>} */
     export let tris
 
@@ -17,31 +14,21 @@
     }
 </script>
 
-<div class="entete-avec-tri">
-    <p>{label}</p>
+<ul>
+    {#each [...tris] as tri}
+        <li>
+            <button type="button" on:click={() => { sélectionnerTri(tri) }}  class={ triSélectionné === tri ? "sélectionné" : "" }>
+                {tri["nom"]}
 
-    <ul>
-        {#each [...tris] as tri}
-            <li>
-                <button type="button" on:click={() => { sélectionnerTri(tri) }}  class={ triSélectionné === tri ? "sélectionné" : "" }>
-                    {tri["nom"]}
-
-                    {#if tri === triSélectionné}
-                        <span class="fr-icon-check-line" aria-hidden="true"></span>
-                    {/if}
-                </button>
-            </li>
-        {/each}
-    </ul>
-</div>
+                {#if tri === triSélectionné}
+                    <span class="fr-icon-check-line" aria-hidden="true"></span>
+                {/if}
+            </button>
+        </li>
+    {/each}
+</ul>
 
 <style lang="scss">
-    .entete-avec-tri {
-        height: 100%;
-        display: flex;
-        flex-direction: column;
-        justify-content: space-between;
-    }
 
     ul {
         list-style: none;
@@ -62,9 +49,14 @@
         text-align: left;
         margin-bottom: 0.25rem;
         background-color: var(--background-overlap-grey);
-        --idle: transparent;
-        --hover: var(--background-overlap-grey-hover);
-        --active: var(--background-overlap-grey-active);
+
+        &:hover{
+            background-color: var(--background-overlap-grey-hover);
+        } 
+        &:active{
+            background-color:var(--background-overlap-grey-active);
+        } 
+
         box-shadow: inset 0 1px 0 0 var(--border-open-blue-france);
 
         &.sélectionné { 

--- a/scripts/front-end/components/TrisDeTh.svelte
+++ b/scripts/front-end/components/TrisDeTh.svelte
@@ -1,5 +1,6 @@
 <script>
     // @ts-check
+    import clsx from 'clsx';
 
     /** @type {Set<{nom: string, tri: function}>} */
     export let tris
@@ -14,10 +15,14 @@
     }
 </script>
 
-<ul>
+<ul class="fr-mt-1w">
     {#each [...tris] as tri}
-        <li>
-            <button type="button" on:click={() => { sélectionnerTri(tri) }}  class={ triSélectionné === tri ? "sélectionné" : "" }>
+        <li class="fr-mb-1v">
+            <button 
+                class={clsx(['fr-pt-1v', 'fr-pb-1v', {"sélectionné": triSélectionné === tri}])} 
+                type="button" 
+                on:click={() => { sélectionnerTri(tri) }}
+            >
                 {tri["nom"]}
 
                 {#if tri === triSélectionné}
@@ -34,7 +39,6 @@
         list-style: none;
         pointer-events: auto;
         padding: 0;
-        margin-top: 0.25rem;
 
         li {
             padding: 0;
@@ -45,9 +49,7 @@
 
     button {
         color: var(--text-mention-grey);
-        padding: 0.5rem;
         text-align: left;
-        margin-bottom: 0.25rem;
         background-color: var(--background-overlap-grey);
 
         &:hover{

--- a/scripts/front-end/components/screens/SuiviInstruction.svelte
+++ b/scripts/front-end/components/screens/SuiviInstruction.svelte
@@ -6,6 +6,7 @@
     import TrisDeTh from '../TrisDeTh.svelte'
     import TagPhase from '../TagPhase.svelte'
     import TagEnjeu from '../TagEnjeu.svelte'
+    import IndicateurDélaiPhase from '../IndicateurDélaiPhase.svelte'
     import {formatLocalisation, formatDéposant, phases, prochaineActionAttenduePar} from '../../affichageDossier.js'
     import {trouverDossiersIdCorrespondantsÀTexte} from '../../rechercherDansDossier.js'
     import {retirerAccents} from '../../../commun/manipulationStrings.js'
@@ -369,7 +370,7 @@
                             déposant_prénoms, communes, départements, régions,
                             activité_principale, rattaché_au_régime_ae,
                             enjeu_politique, enjeu_écologique,
-                            évènementsPhase, prochaine_action_attendue_par }}
+                            évènementsPhase, prochaine_action_attendue_par }, i}
                                 {@const phase = /** @type {DossierPhase} */ (évènementsPhase[0].phase)}
                                 <tr>
                                     <td><a href={`/dossier/${id}`}>Voir le dossier</a></td>
@@ -391,6 +392,7 @@
                                     </td>
                                     <td>
                                         <TagPhase {phase} taille='SM'></TagPhase>
+                                        <IndicateurDélaiPhase dossier={dossiersSelectionnés[i]}></IndicateurDélaiPhase>
                                         {#if prochaine_action_attendue_par}
                                             <p class="fr-tag fr-tag--sm fr-mt-1w">{prochaine_action_attendue_par}</p>
                                         {/if}

--- a/scripts/front-end/components/screens/SuiviInstruction.svelte
+++ b/scripts/front-end/components/screens/SuiviInstruction.svelte
@@ -9,7 +9,7 @@
     import {formatLocalisation, formatDéposant, phases, prochaineActionAttenduePar} from '../../affichageDossier.js'
     import {trouverDossiersIdCorrespondantsÀTexte} from '../../rechercherDansDossier.js'
     import {retirerAccents} from '../../../commun/manipulationStrings.js'
-    import {trierDossiersParOrdreAlphabétiqueColonne} from '../../triDossiers.js'
+    import {trierDossiersParOrdreAlphabétiqueColonne, trierDossiersParPhaseProchaineAction} from '../../triDossiers.js'
 
     /** @import {ComponentProps} from 'svelte' */
     /** @import {DossierComplet, DossierPhase, DossierProchaineActionAttenduePar} from '../../../types/API_Pitchou.js' */
@@ -255,6 +255,10 @@
         { nom: "Trier de A à Z", tri: () => dossiersSelectionnés = trierDossiersParOrdreAlphabétiqueColonne(dossiersSelectionnés, "déposant") },
         { nom: "Trier de Z à A", tri: () => dossiersSelectionnés = trierDossiersParOrdreAlphabétiqueColonne(dossiersSelectionnés, "déposant").reverse() },
     ])
+
+    const triPriorisationPhaseProchaineAction = new Set([
+        { nom: "Prioriser", tri: () => dossiersSelectionnés = trierDossiersParPhaseProchaineAction(dossiersSelectionnés) },
+    ])
 </script>
 
 <Squelette {email} {erreurs}>
@@ -354,7 +358,7 @@
                                     <br>
                                     Prochaine action attendue de
                                     <TrisDeTh
-                                        tris={trisNomProjet}
+                                        tris={triPriorisationPhaseProchaineAction}
                                         bind:triSélectionné
                                     />
                                 </th>

--- a/scripts/front-end/components/screens/SuiviInstruction.svelte
+++ b/scripts/front-end/components/screens/SuiviInstruction.svelte
@@ -3,7 +3,7 @@
     import Squelette from '../Squelette.svelte'
     import FiltreParmiOptions from '../FiltreParmiOptions.svelte'
     import BarreRecherche from '../BarreRecherche.svelte'
-    import EnteteAvecTri from '../EnteteAvecTri.svelte'
+    import TrisDeTh from '../TrisDeTh.svelte'
     import TagPhase from '../TagPhase.svelte'
     import TagEnjeu from '../TagEnjeu.svelte'
     import {formatLocalisation, formatDéposant, phases, prochaineActionAttenduePar} from '../../affichageDossier.js'
@@ -320,29 +320,29 @@
                             <tr>
                                 <th>Voir le dossier</th>
                                 <th>
-                                    <EnteteAvecTri
-                                        label="Localisation"
+                                    Localisation
+                                    <TrisDeTh
                                         tris={trisLocalisation}
                                         bind:triSélectionné
                                     />
                                 </th>
                                 <th>
-                                    <EnteteAvecTri
-                                        label="Activité principale"
+                                    Activité principale
+                                    <TrisDeTh
                                         tris={trisActivitéPrincipale}
                                         bind:triSélectionné
                                     />
                                 </th>
                                 <th>
-                                    <EnteteAvecTri
-                                        label="Porteur de projet"
+                                    Porteur de projet
+                                    <TrisDeTh
                                         tris={trisDéposant}
                                         bind:triSélectionné
                                     />
                                 </th>
                                 <th>
-                                    <EnteteAvecTri
-                                        label="Nom du projet"
+                                    Nom du projet
+                                    <TrisDeTh
                                         tris={trisNomProjet}
                                         bind:triSélectionné
                                     />
@@ -353,6 +353,10 @@
                                     Phase<br>
                                     <br>
                                     Prochaine action attendue de
+                                    <TrisDeTh
+                                        tris={trisNomProjet}
+                                        bind:triSélectionné
+                                    />
                                 </th>
                             </tr>
                         </thead>

--- a/scripts/front-end/getDébutPhaseActuelle.js
+++ b/scripts/front-end/getDébutPhaseActuelle.js
@@ -1,0 +1,33 @@
+//@ts-ignore
+/** @import {DossierComplet, DossierPhase} from '../types/API_Pitchou.js' */
+//@ts-ignore
+/** @import {default as ÉvènementPhaseDossier} from '../types/database/public/ÉvènementPhaseDossier.js' */
+
+
+/**
+ * 
+ * @param { DossierComplet & {évènementsPhase: ÉvènementPhaseDossier[]} } dossier
+ * @returns { {phase: DossierPhase, dateDébut: Date}}
+ */
+export function getDébutPhaseActuelle(dossier){
+    // C'est trop simpliste
+    // PPP à revoir à l'occasion de https://trello.com/c/GmhEx16G/420-un-dossier-qui-passe-en-instruction-dans-ds-reste-en-instruction-dans-pitchou
+    /** @type {DossierPhase}*/
+    // @ts-ignore
+    const phaseActuelle = dossier.évènementsPhase[0].phase
+
+    /** @type {Date} */
+    let dateDébut;
+
+    if(phaseActuelle === 'Accompagnement amont'){
+        const {date_dépôt} = dossier
+
+        dateDébut = date_dépôt
+    }
+    else{
+        dateDébut = dossier.évènementsPhase[0].horodatage
+    }
+
+
+    return { dateDébut, phase: phaseActuelle}
+}

--- a/scripts/front-end/triDossiers.js
+++ b/scripts/front-end/triDossiers.js
@@ -105,7 +105,8 @@ export function trierDossiersParPhaseProchaineAction(dossiers){
             return phaseComparison
         }
         else{
-            // les phases sont similaires, comparer sur de qui la prochaine action est attendue
+            // les phases sont similaires, 
+            // comparer sur de qui la prochaine action est attendue
             const prochaineActionAttenduePar1 = dossier1.prochaine_action_attendue_par
             const prochaineActionAttenduePar2 = dossier2.prochaine_action_attendue_par
 
@@ -116,7 +117,8 @@ export function trierDossiersParPhaseProchaineAction(dossiers){
                 return prochaineActionAttendueParComparison
             }
             else{
-                // les prochaineActionAttenduePar sont aussi similaires, comparer sur
+                // les prochaineActionAttenduePar sont aussi similaires
+                // comparer sur l'ancienneté (dossier le plus ancien le plus pertinent)
                 return 0
             }
         }

--- a/scripts/front-end/triDossiers.js
+++ b/scripts/front-end/triDossiers.js
@@ -1,4 +1,4 @@
-/** @import {DossierComplet} from '../types/API_Pitchou.js' */
+/** @import {DossierComplet, DossierPhase, DossierProchaineActionAttenduePar} from '../types/API_Pitchou.js' */
 /** @import {default as ÉvènementPhaseDossier} from '../types/database/public/ÉvènementPhaseDossier.ts' */
 
 import {formatLocalisation, formatDéposant} from './affichageDossier.js'
@@ -38,5 +38,87 @@ export const trierDossiersParOrdreAlphabétiqueColonne = (dossiers, nomColonne) 
         if (colonneA && !colonneB) return -1
 
         return 0
+    })
+}
+
+/** @type {{[k in DossierPhase]: number}} */
+const phaseToImportance = {
+    'Accompagnement amont': 6,
+    'Étude recevabilité DDEP': 5,
+    'Instruction': 4,
+    'Contrôle': 3,
+    'Classé sans suite': 2,
+    'Obligations terminées': 1,
+}
+
+/**
+ * Retourne un nombre positif si la phase1 est plus importante que la phase2
+ * 
+ * @param {DossierPhase} phase1 
+ * @param {DossierPhase} phase2 
+ */
+function comparePhase(phase1, phase2){
+    return phaseToImportance[phase2] - phaseToImportance[phase1]
+}
+
+
+/** @type {{[k in DossierProchaineActionAttenduePar]: number}} */
+const prochaineActionAttendueParToImportance = {
+    'Instructeur': 10,
+    'Consultation du public': 9,
+    'CNPN/CSRPN': 8,
+    'Pétitionnaire': 7,
+    'Autre administration': 6,
+    'Autre': 5,
+    'Personne': 4
+}
+
+/**
+ * Retourne un nombre positif si la phase1 est plus importante que la phase2
+ * 
+ * @param {DossierProchaineActionAttenduePar} prochaineActionAttenduePar1
+ * @param {DossierProchaineActionAttenduePar} prochaineActionAttenduePar2 
+ */
+function compareProchaineActionAttenduePar(prochaineActionAttenduePar1, prochaineActionAttenduePar2){
+    const importance1 = prochaineActionAttenduePar1 ? prochaineActionAttendueParToImportance[prochaineActionAttenduePar1] : 0;
+    const importance2 = prochaineActionAttenduePar2 ? prochaineActionAttendueParToImportance[prochaineActionAttenduePar2] : 0;
+
+    return importance2 - importance1
+}
+
+
+
+/**
+ * 
+ * @param {(DossierComplet & {évènementsPhase: ÉvènementPhaseDossier[]})[]} dossiers 
+ * @returns {(DossierComplet & {évènementsPhase: ÉvènementPhaseDossier[]})[]}
+ */
+export function trierDossiersParPhaseProchaineAction(dossiers){
+    return dossiers.toSorted((dossier1, dossier2) => {
+        const phase1 = dossier1.évènementsPhase[0].phase
+        const phase2 = dossier2.évènementsPhase[0].phase
+
+        // @ts-ignore
+        const phaseComparison = comparePhase(phase1, phase2)
+
+        if(phaseComparison !== 0){
+            return phaseComparison
+        }
+        else{
+            // les phases sont similaires, comparer sur de qui la prochaine action est attendue
+            const prochaineActionAttenduePar1 = dossier1.prochaine_action_attendue_par
+            const prochaineActionAttenduePar2 = dossier2.prochaine_action_attendue_par
+
+            // @ts-ignore
+            const prochaineActionAttendueParComparison = compareProchaineActionAttenduePar(prochaineActionAttenduePar1, prochaineActionAttenduePar2)
+
+            if(prochaineActionAttendueParComparison !== 0){
+                return prochaineActionAttendueParComparison
+            }
+            else{
+                // les prochaineActionAttenduePar sont aussi similaires, comparer sur
+                return 0
+            }
+        }
     })
 }

--- a/scripts/front-end/triDossiers.js
+++ b/scripts/front-end/triDossiers.js
@@ -3,6 +3,8 @@
 
 import {formatLocalisation, formatDéposant} from './affichageDossier.js'
 
+import {getDébutPhaseActuelle} from './getDébutPhaseActuelle.js'
+
 /**
  * 
  * @param {(DossierComplet & {évènementsPhase: ÉvènementPhaseDossier[]})[]} dossiers 
@@ -80,8 +82,8 @@ const prochaineActionAttendueParToImportance = {
  * @param {DossierProchaineActionAttenduePar} prochaineActionAttenduePar2 
  */
 function compareProchaineActionAttenduePar(prochaineActionAttenduePar1, prochaineActionAttenduePar2){
-    const importance1 = prochaineActionAttenduePar1 ? prochaineActionAttendueParToImportance[prochaineActionAttenduePar1] : 0;
-    const importance2 = prochaineActionAttenduePar2 ? prochaineActionAttendueParToImportance[prochaineActionAttenduePar2] : 0;
+    const importance1 = prochaineActionAttenduePar1 ? prochaineActionAttendueParToImportance[prochaineActionAttenduePar1] : 11;
+    const importance2 = prochaineActionAttenduePar2 ? prochaineActionAttendueParToImportance[prochaineActionAttenduePar2] : 11;
 
     return importance2 - importance1
 }
@@ -117,9 +119,12 @@ export function trierDossiersParPhaseProchaineAction(dossiers){
                 return prochaineActionAttendueParComparison
             }
             else{
+                const {dateDébut: dateDébut1} = getDébutPhaseActuelle(dossier1)
+                const {dateDébut: dateDébut2} = getDébutPhaseActuelle(dossier2)
                 // les prochaineActionAttenduePar sont aussi similaires
                 // comparer sur l'ancienneté (dossier le plus ancien le plus pertinent)
-                return 0
+
+                return dateDébut1.getTime() - dateDébut2.getTime()
             }
         }
     })

--- a/scripts/types/database/public/Dossier.ts
+++ b/scripts/types/database/public/Dossier.ts
@@ -15,7 +15,7 @@ export default interface Dossier {
 
   statut: string | null;
 
-  date_dépôt: Date | null;
+  date_dépôt: Date;
 
   espèces_protégées_concernées: string | null;
 
@@ -84,8 +84,6 @@ export default interface Dossier {
   prochaine_action_attendue_par: string | null;
 
   activité_principale: string | null;
-
-  prochaine_action_attendue: string | null;
 }
 
 /** Represents the initializer for the table public.dossier */
@@ -97,7 +95,7 @@ export interface DossierInitializer {
 
   statut?: string | null;
 
-  date_dépôt?: Date | null;
+  date_dépôt: Date;
 
   espèces_protégées_concernées?: string | null;
 
@@ -166,8 +164,6 @@ export interface DossierInitializer {
   prochaine_action_attendue_par?: string | null;
 
   activité_principale?: string | null;
-
-  prochaine_action_attendue?: string | null;
 }
 
 /** Represents the mutator for the table public.dossier */
@@ -178,7 +174,7 @@ export interface DossierMutator {
 
   statut?: string | null;
 
-  date_dépôt?: Date | null;
+  date_dépôt?: Date;
 
   espèces_protégées_concernées?: string | null;
 
@@ -247,6 +243,4 @@ export interface DossierMutator {
   prochaine_action_attendue_par?: string | null;
 
   activité_principale?: string | null;
-
-  prochaine_action_attendue?: string | null;
 }


### PR DESCRIPTION
~~PR créée par-dessus #148~~

~~Je ferai un cherry-pick/rebase une fois que #148 aura été mergée~~

ayé, c'est bon

---

J'ai commencé par un nettoyage visuel et du code des tris dans les en-tête
Le format avec le `label` en argument empêchait l'affichage de la colonne "phase + prochaine action attendue de"

J'ai fait des petits commits clairs, donc, je pense qu'une revue commit par commit peut faire sens
