### PR TITLE
Garder filtres et tris

### DIFF
--- a/scripts/front-end/components/FiltreParmiOptions.svelte
+++ b/scripts/front-end/components/FiltreParmiOptions.svelte
@@ -35,18 +35,12 @@
         mettreÀJourOptionsSélectionnées(optionsSélectionnées)
     }
 
-    /**
-     * @param {MouseEvent} e
-     */
-    function selectionnerTout(e){
+    function selectionnerTout(){
         optionsSélectionnées = new Set(options)
         mettreÀJourOptionsSélectionnées(optionsSélectionnées)
     }
 
-    /**
-     * @param {MouseEvent} e
-     */
-    function selectionnerRien(e){
+    function selectionnerRien(){
         optionsSélectionnées = new Set()
         mettreÀJourOptionsSélectionnées(optionsSélectionnées)
     }

--- a/scripts/front-end/components/FiltreParmiOptions.svelte
+++ b/scripts/front-end/components/FiltreParmiOptions.svelte
@@ -35,21 +35,42 @@
         mettreÀJourOptionsSélectionnées(optionsSélectionnées)
     }
 
-    function selectionnerTout(){
+    /**
+     * @param {MouseEvent} e
+     */
+    function selectionnerTout(e){
         optionsSélectionnées = new Set(options)
         mettreÀJourOptionsSélectionnées(optionsSélectionnées)
     }
 
-
-    function selectionnerRien(){
+    /**
+     * @param {MouseEvent} e
+     */
+    function selectionnerRien(e){
         optionsSélectionnées = new Set()
         mettreÀJourOptionsSélectionnées(optionsSélectionnées)
     }
 
+    let open = false;
+
+    /** @type {HTMLElement} */
+    let details;
+
+    /**
+     * @param {MouseEvent} e
+     */
+    function detailsOnClick(e){
+        // @ts-ignore
+        if(!details.contains(e.target)){
+            open = false
+        }
+    }
 
 </script>
 
-<details>
+<svelte:body on:click={detailsOnClick}/>
+
+<details bind:open bind:this={details}>
     <summary class="fr-btn fr-btn--secondary fr-btn--sm">
         {titre}
     </summary>

--- a/scripts/front-end/components/TrisDeTh.svelte
+++ b/scripts/front-end/components/TrisDeTh.svelte
@@ -2,21 +2,23 @@
     // @ts-check
     import clsx from 'clsx';
 
-    /** @type {Set<{nom: string, tri: function}>} */
+    /** @import  { TriTableauSuiviDDEP } from '../../types/interfaceUtilisateur.ts' */
+
+    /** @type {TriTableauSuiviDDEP[]} */
     export let tris
 
-    /** @type {{nom: string, tri: function}|undefined} */
+    /** @type {TriTableauSuiviDDEP | undefined} */
     export let triSélectionné = undefined
 
-    /** @type {(tri: {nom: string, tri: function}) => void} */
+    /** @type {(tri: TriTableauSuiviDDEP) => void} */
     const sélectionnerTri = (tri) => { 
         triSélectionné = tri
-        tri["tri"]()
+        tri.trier()
     }
 </script>
 
 <ul class="fr-mt-1w">
-    {#each [...tris] as tri}
+    {#each tris as tri}
         <li class="fr-mb-1v">
             <button 
                 class={clsx(['fr-pt-1v', 'fr-pb-1v', {"sélectionné": triSélectionné === tri}])} 

--- a/scripts/front-end/components/screens/Dossier.svelte
+++ b/scripts/front-end/components/screens/Dossier.svelte
@@ -67,26 +67,5 @@
 </Squelette>
 
 <style lang="scss">
-    article {
-        background-color: var(--background-alt-grey);
-    }
 
-    section {
-        margin-bottom: 3rem;
-    }
-
-    select {
-        max-width: 90%;
-    }
-
-    .liste-espèces{
-        max-width: 40rem;
-        overflow: hidden;
-        white-space: nowrap;
-    }
-
-    nav.dossier-nav {
-        display: flex;
-        flex-direction: column;
-    }
 </style>

--- a/scripts/front-end/components/screens/SuiviInstruction.svelte
+++ b/scripts/front-end/components/screens/SuiviInstruction.svelte
@@ -62,13 +62,10 @@
     let dossiersSelectionnés = []
     //$: console.log('dossiersSelectionnés', dossiersSelectionnés)
 
-    $: dossiersNonSélectionnés = (new Set(dossiers)).difference(new Set(dossiersSelectionnés))
-
-    $: console.log('dossiersNonSélectionnés', dossiersNonSélectionnés)
-
-    $: dossierNonSel = [...dossiersNonSélectionnés][0]
-
-    $: console.log('dossier non sélectionné', dossierNonSel, dossierNonSel.activité_principale, dossierNonSel.phase, dossierNonSel.prochaine_action_attendue_par)
+    //$: dossiersNonSélectionnés = (new Set(dossiers)).difference(new Set(dossiersSelectionnés))
+    //$: console.log('dossiersNonSélectionnés', dossiersNonSélectionnés)
+    //$: dossierNonSel = [...dossiersNonSélectionnés][0]
+    //$: dossierNonSel && console.log('dossier non sélectionné', dossierNonSel, dossierNonSel.activité_principale, dossierNonSel.phase, dossierNonSel.prochaine_action_attendue_par)
 
 
     const trisActivitéPrincipale = [
@@ -173,7 +170,7 @@
         new Set(prochainesActionsAttenduesParOptions)
 
     tousLesFiltres.set("prochaine action attendue de", dossier => {
-        if (!dossier.prochaine_action_attendue_par) {
+        if (!dossier.prochaine_action_attendue_par || !prochainesActionsAttenduesParOptions.has(dossier.prochaine_action_attendue_par)) {
             return prochainesActionsAttenduesParSélectionnés.has(PROCHAINE_ACTION_ATTENDUE_PAR_VIDE)
         }
 
@@ -303,10 +300,10 @@
     )
 
     tousLesFiltres.set('activité principale', dossier => {
-        if(!dossier.activité_principale)
+        if(!dossier.activité_principale || !activitésPrincipalesOptions.has(dossier.activité_principale))
             return activitésPrincipalesSélectionnées.has(AUCUNE_ACTIVITÉ_PRINCIPALE)
-        else
-            return activitésPrincipalesSélectionnées.has(dossier.activité_principale)
+        
+        return activitésPrincipalesSélectionnées.has(dossier.activité_principale)
     })
 
     /**

--- a/scripts/front-end/components/screens/SuiviInstruction.svelte
+++ b/scripts/front-end/components/screens/SuiviInstruction.svelte
@@ -100,7 +100,7 @@
     let triSélectionné = tris.find(t => t.id === triIdSélectionné) || triPriorisationPhaseProchaineAction[0]
 
 
-    /** @type {Map<'département' | 'commune' | 'phase' | 'prochaine action attendue de' | 'texte' | 'suivis' | 'instructeurs' | 'activité principale', (d: DossierRésumé) => boolean>} */
+    /** @type {Map<'phase' | 'prochaine action attendue de' | 'texte' | 'suivis' | 'instructeurs' | 'activité principale', (d: DossierRésumé) => boolean>} */
     const tousLesFiltres = new Map()
 
     function filtrerDossiers(){
@@ -159,7 +159,9 @@
 
     /** @type {Set<DossierProchaineActionAttenduePar | PROCHAINE_ACTION_ATTENDUE_PAR_VIDE>} */
     // @ts-ignore
-    let prochainesActionsAttenduesParFiltrées = new Set()
+    let prochainesActionsAttenduesParSélectionnés = filtresSélectionnés['prochaine action attendue de'] ?
+        new Set(filtresSélectionnés['prochaine action attendue de']) :
+        new Set()
 
     /**
      *
@@ -176,7 +178,7 @@
         })
 
         // @ts-ignore
-        prochainesActionsAttenduesParFiltrées = new Set(prochainesActionsAttenduesParSélectionnées)
+        prochainesActionsAttenduesParSélectionnés = new Set(prochainesActionsAttenduesParSélectionnées)
 
         filtrerDossiers()
     }
@@ -300,7 +302,8 @@
     }
 
     $: rememberTriFiltres(triSélectionné, {
-        phases: phasesSélectionnées
+        phases: phasesSélectionnées,
+        'prochaine action attendue de': prochainesActionsAttenduesParSélectionnés
     })
 
     // filtrage avec les filtres initiaux
@@ -339,6 +342,7 @@
                     <FiltreParmiOptions
                         titre="Filtrer par prochaine action attendue par"
                         options={prochainesActionsAttenduesParOptions}
+                        optionsSélectionnées={prochainesActionsAttenduesParSélectionnés}
                         mettreÀJourOptionsSélectionnées={filtrerParProchainesActionsAttenduesPar}
                     />
                     {#if instructeursOptions && instructeursOptions.size >= 2}
@@ -362,10 +366,10 @@
                             {/each}
                         </div>
                     {/if}
-                    {#if prochainesActionsAttenduesParFiltrées.size >= 1}
+                    {#if prochainesActionsAttenduesParSélectionnés.size >= 1}
                         <div class="fr-mb-1w">
                             <span>Prochaine action attendue par&nbsp;:</span>
-                            {#each [...prochainesActionsAttenduesParFiltrées] as prochaineActionAttenduePar}
+                            {#each [...prochainesActionsAttenduesParSélectionnés] as prochaineActionAttenduePar}
                                 <span class="fr-tag fr-tag--sm fr-mr-1w fr-mb-1v">
                                     {prochaineActionAttenduePar}
                                 </span>

--- a/scripts/front-end/components/screens/SuiviInstruction.svelte
+++ b/scripts/front-end/components/screens/SuiviInstruction.svelte
@@ -65,7 +65,9 @@
 		}
 
 		dossiersSelectionnés = nouveauxDossiersSélectionnés;
-        triSélectionné = undefined
+        if(triSélectionné){
+            triSélectionné.tri()
+        }
 	}
 
 

--- a/scripts/front-end/components/screens/SuiviInstruction.svelte
+++ b/scripts/front-end/components/screens/SuiviInstruction.svelte
@@ -62,6 +62,15 @@
     let dossiersSelectionnés = []
     //$: console.log('dossiersSelectionnés', dossiersSelectionnés)
 
+    $: dossiersNonSélectionnés = (new Set(dossiers)).difference(new Set(dossiersSelectionnés))
+
+    $: console.log('dossiersNonSélectionnés', dossiersNonSélectionnés)
+
+    $: dossierNonSel = [...dossiersNonSélectionnés][0]
+
+    $: console.log('dossier non sélectionné', dossierNonSel, dossierNonSel.activité_principale, dossierNonSel.phase, dossierNonSel.prochaine_action_attendue_par)
+
+
     const trisActivitéPrincipale = [
         { nom: "Trier de A à Z", trier(){ dossiersSelectionnés = trierDossiersParOrdreAlphabétiqueColonne(dossiersSelectionnés, "activité_principale") }, id: 'ActivitéPrincipale-AZ' },
         { nom: "Trier de Z à A", trier(){ dossiersSelectionnés = trierDossiersParOrdreAlphabétiqueColonne(dossiersSelectionnés, "activité_principale").reverse()}, id: 'ActivitéPrincipale-ZA' },
@@ -282,17 +291,20 @@
 	}
 
 
+    const AUCUNE_ACTIVITÉ_PRINCIPALE = '(aucune activité principale)'
+    // @ts-ignore
+    const activitésPrincipalesOptions = new Set([AUCUNE_ACTIVITÉ_PRINCIPALE, ...activitésPrincipales])
 
-    /** @type {Set<DossierDemarcheSimplifiee88444["Activité principale"]>} */
+    /** @type {Set<DossierDemarcheSimplifiee88444["Activité principale"] | AUCUNE_ACTIVITÉ_PRINCIPALE>} */
     // @ts-ignore
     let activitésPrincipalesSélectionnées = new Set(filtresSélectionnés.activitésPrincipales ?
         filtresSélectionnés.activitésPrincipales :
-        activitésPrincipales
+        activitésPrincipalesOptions
     )
 
     tousLesFiltres.set('activité principale', dossier => {
         if(!dossier.activité_principale)
-            return false
+            return activitésPrincipalesSélectionnées.has(AUCUNE_ACTIVITÉ_PRINCIPALE)
         else
             return activitésPrincipalesSélectionnées.has(dossier.activité_principale)
     })
@@ -307,9 +319,7 @@
 		filtrerDossiers()
     }
 
-    let activitésPrincipalesSet = new Set(activitésPrincipales)
-
-    $: activitésPrincipalesNonSélectionnées = activitésPrincipalesSet.difference(activitésPrincipalesSélectionnées)
+    $: activitésPrincipalesNonSélectionnées = activitésPrincipalesOptions.difference(activitésPrincipalesSélectionnées)
 
     $: rememberTriFiltres(triSélectionné, {
         phases: phasesSélectionnées,
@@ -348,7 +358,7 @@
                 <div class="filtres">
                     <FiltreParmiOptions
                         titre="Filtrer par activité principale"
-                        options={new Set(activitésPrincipales)}
+                        options={activitésPrincipalesOptions}
                         optionsSélectionnées={activitésPrincipalesSélectionnées}
                         mettreÀJourOptionsSélectionnées={filtrerParActivitéPrincipale}
                     />

--- a/scripts/front-end/components/screens/SuiviInstruction.svelte
+++ b/scripts/front-end/components/screens/SuiviInstruction.svelte
@@ -48,7 +48,7 @@
     })()
 
     /** @type {DossierRésumé[]} */
-    $: dossiersSelectionnés = []
+    let dossiersSelectionnés = []
     //$: console.log('dossiersSelectionnés', dossiersSelectionnés)
 
     /** @type {{nom: string, tri: function}|undefined} */

--- a/scripts/front-end/components/screens/SuiviInstruction.svelte
+++ b/scripts/front-end/components/screens/SuiviInstruction.svelte
@@ -161,25 +161,24 @@
     // @ts-ignore
     let prochainesActionsAttenduesParSélectionnés = filtresSélectionnés['prochaine action attendue de'] ?
         new Set(filtresSélectionnés['prochaine action attendue de']) :
-        new Set()
+        new Set(prochainesActionsAttenduesParOptions)
+
+    tousLesFiltres.set("prochaine action attendue de", dossier => {
+        if (!dossier.prochaine_action_attendue_par) {
+            return prochainesActionsAttenduesParSélectionnés.has(PROCHAINE_ACTION_ATTENDUE_PAR_VIDE)
+        }
+
+        // @ts-ignore
+        return prochainesActionsAttenduesParSélectionnés.has(dossier.prochaine_action_attendue_par)
+    })
 
     /**
      *
-     * @param {Set<DossierProchaineActionAttenduePar | PROCHAINE_ACTION_ATTENDUE_PAR_VIDE>} prochainesActionsAttenduesParSélectionnées
+     * @param {Set<DossierProchaineActionAttenduePar | PROCHAINE_ACTION_ATTENDUE_PAR_VIDE>} _prochainesActionsAttenduesParSélectionnés
      */
-    function filtrerParProchainesActionsAttenduesPar(prochainesActionsAttenduesParSélectionnées) {
-        tousLesFiltres.set("prochaine action attendue de", dossier => {
-            if (prochainesActionsAttenduesParSélectionnées.has(PROCHAINE_ACTION_ATTENDUE_PAR_VIDE)) {
-                return !dossier.prochaine_action_attendue_par
-            }
-
-            // @ts-ignore
-            return prochainesActionsAttenduesParSélectionnées.has(dossier.prochaine_action_attendue_par)
-        })
-
-        // @ts-ignore
-        prochainesActionsAttenduesParSélectionnés = new Set(prochainesActionsAttenduesParSélectionnées)
-
+    function filtrerParProchainesActionsAttenduesPar(_prochainesActionsAttenduesParSélectionnés) {
+        prochainesActionsAttenduesParSélectionnés = new Set(_prochainesActionsAttenduesParSélectionnés)
+        
         filtrerDossiers()
     }
 

--- a/scripts/front-end/components/screens/SuiviInstruction.svelte
+++ b/scripts/front-end/components/screens/SuiviInstruction.svelte
@@ -12,12 +12,14 @@
     import {trouverDossiersIdCorrespondantsÀTexte} from '../../rechercherDansDossier.js'
     import {retirerAccents} from '../../../commun/manipulationStrings.js'
     import {trierDossiersParOrdreAlphabétiqueColonne, trierDossiersParPhaseProchaineAction} from '../../triDossiers.js'
-
+    
     /** @import {ComponentProps} from 'svelte' */
     /** @import {DossierDemarcheSimplifiee88444} from '../../../types/démarches-simplifiées/DémarcheSimplifiée88444.ts'*/
     /** @import {DossierRésumé, DossierPhase, DossierProchaineActionAttenduePar} from '../../../types/API_Pitchou.ts' */
     /** @import {PitchouState} from '../../store.js' */
     /** @import {default as Personne} from '../../../types/database/public/Personne.ts' */
+    /** @import  { TriTableauSuiviDDEP } from '../../../types/interfaceUtilisateur.ts' */
+
 
     /** @type {DossierRésumé[]} */
     export let dossiers = []
@@ -51,7 +53,7 @@
     let dossiersSelectionnés = []
     //$: console.log('dossiersSelectionnés', dossiersSelectionnés)
 
-    /** @type {{nom: string, tri: function}|undefined} */
+    /** @type {TriTableauSuiviDDEP | undefined} */
     let triSélectionné = undefined
 
     /** @type {Map<'département' | 'commune' | 'phase' | 'prochaine action attendue de' | 'texte' | 'suivis' | 'instructeurs' | 'activité principale', (d: DossierRésumé) => boolean>} */
@@ -66,7 +68,7 @@
 
 		dossiersSelectionnés = nouveauxDossiersSélectionnés;
         if(triSélectionné){
-            triSélectionné.tri()
+            triSélectionné.trier()
         }
 	}
 
@@ -110,7 +112,7 @@
 
     /** @type {Set<DossierProchaineActionAttenduePar | PROCHAINE_ACTION_ATTENDUE_PAR_VIDE>} */
     // @ts-ignore
-    $: prochainesActionsAttenduesParFiltrées = new Set()
+    let prochainesActionsAttenduesParFiltrées = new Set()
 
     /**
      *
@@ -132,7 +134,7 @@
         filtrerDossiers()
     }
 
-    $: texteÀChercher = ''
+    let texteÀChercher = ''
 
     /**
      * @param {string} _texteÀChercher
@@ -231,12 +233,12 @@
 
 
     /** @type {Set<DossierDemarcheSimplifiee88444["Activité principale"]>} */
-    $: activitésPrincipalesSélectionnées = new Set()
+    let activitésPrincipalesSélectionnées = new Set()
+
     /**
      *
      * @param {Set<DossierDemarcheSimplifiee88444["Activité principale"]>} _activitésPrincipalesSélectionnées
      */
-
     function filtrerParActivitéPrincipale(_activitésPrincipalesSélectionnées) {
         tousLesFiltres.set('activité principale', dossier => {
             if(!dossier.activité_principale)
@@ -250,29 +252,29 @@
 		filtrerDossiers()
     }
 
-    const trisActivitéPrincipale = new Set([
-        { nom: "Trier de A à Z", tri: () => dossiersSelectionnés = trierDossiersParOrdreAlphabétiqueColonne(dossiersSelectionnés, "activité_principale") },
-        { nom: "Trier de Z à A", tri: () => dossiersSelectionnés = trierDossiersParOrdreAlphabétiqueColonne(dossiersSelectionnés, "activité_principale").reverse() },
-    ])
+    const trisActivitéPrincipale = [
+        { nom: "Trier de A à Z", trier(){ dossiersSelectionnés = trierDossiersParOrdreAlphabétiqueColonne(dossiersSelectionnés, "activité_principale") }, },
+        { nom: "Trier de Z à A", trier(){ dossiersSelectionnés = trierDossiersParOrdreAlphabétiqueColonne(dossiersSelectionnés, "activité_principale").reverse()},  },
+    ]
 
-    const trisNomProjet = new Set([
-        { nom: "Trier de A à Z", tri: () => dossiersSelectionnés = trierDossiersParOrdreAlphabétiqueColonne(dossiersSelectionnés, "nom") },
-        { nom: "Trier de Z à A", tri: () => dossiersSelectionnés = trierDossiersParOrdreAlphabétiqueColonne(dossiersSelectionnés, "nom").reverse() },
-    ])
+    const trisNomProjet = [
+        { nom: "Trier de A à Z", trier(){ dossiersSelectionnés = trierDossiersParOrdreAlphabétiqueColonne(dossiersSelectionnés, "nom") } },
+        { nom: "Trier de Z à A", trier(){ dossiersSelectionnés = trierDossiersParOrdreAlphabétiqueColonne(dossiersSelectionnés, "nom").reverse() } },
+    ]
 
-    const trisLocalisation = new Set([
-        { nom: "Trier de A à Z", tri: () => dossiersSelectionnés = trierDossiersParOrdreAlphabétiqueColonne(dossiersSelectionnés, "localisation") },
-        { nom: "Trier de Z à A", tri: () => dossiersSelectionnés = trierDossiersParOrdreAlphabétiqueColonne(dossiersSelectionnés, "localisation").reverse() },
-    ])
+    const trisLocalisation = [
+        { nom: "Trier de A à Z", trier(){ dossiersSelectionnés = trierDossiersParOrdreAlphabétiqueColonne(dossiersSelectionnés, "localisation") } },
+        { nom: "Trier de Z à A", trier(){ dossiersSelectionnés = trierDossiersParOrdreAlphabétiqueColonne(dossiersSelectionnés, "localisation").reverse() } },
+    ]
 
-    const trisDéposant = new Set([
-        { nom: "Trier de A à Z", tri: () => dossiersSelectionnés = trierDossiersParOrdreAlphabétiqueColonne(dossiersSelectionnés, "déposant") },
-        { nom: "Trier de Z à A", tri: () => dossiersSelectionnés = trierDossiersParOrdreAlphabétiqueColonne(dossiersSelectionnés, "déposant").reverse() },
-    ])
+    const trisDéposant = [
+        { nom: "Trier de A à Z", trier(){ dossiersSelectionnés = trierDossiersParOrdreAlphabétiqueColonne(dossiersSelectionnés, "déposant") } },
+        { nom: "Trier de Z à A", trier(){ dossiersSelectionnés = trierDossiersParOrdreAlphabétiqueColonne(dossiersSelectionnés, "déposant").reverse() } },
+    ]
 
-    const triPriorisationPhaseProchaineAction = new Set([
-        { nom: "Prioriser", tri: () => dossiersSelectionnés = trierDossiersParPhaseProchaineAction(dossiersSelectionnés) },
-    ])
+    const triPriorisationPhaseProchaineAction = [
+        { nom: "Prioriser", trier(){ dossiersSelectionnés = trierDossiersParPhaseProchaineAction(dossiersSelectionnés) } }
+    ]
 
     // filtrage avec les filtres initiaux
     onMount(async () => {

--- a/scripts/front-end/components/screens/SuiviInstruction.svelte
+++ b/scripts/front-end/components/screens/SuiviInstruction.svelte
@@ -285,29 +285,38 @@
 
 
     /** @type {Set<DossierDemarcheSimplifiee88444["Activité principale"]>} */
-    let activitésPrincipalesSélectionnées = new Set()
+    // @ts-ignore
+    let activitésPrincipalesSélectionnées = new Set(filtresSélectionnés.activitésPrincipales ?
+        filtresSélectionnés.activitésPrincipales :
+        activitésPrincipales
+    )
+
+    tousLesFiltres.set('activité principale', dossier => {
+        if(!dossier.activité_principale)
+            return false
+        else
+            return activitésPrincipalesSélectionnées.has(dossier.activité_principale)
+    })
 
     /**
      *
      * @param {Set<DossierDemarcheSimplifiee88444["Activité principale"]>} _activitésPrincipalesSélectionnées
      */
     function filtrerParActivitéPrincipale(_activitésPrincipalesSélectionnées) {
-        tousLesFiltres.set('activité principale', dossier => {
-            if(!dossier.activité_principale)
-                return false
-            else
-                return _activitésPrincipalesSélectionnées.has(dossier.activité_principale)
-        })
-
         activitésPrincipalesSélectionnées = new Set(_activitésPrincipalesSélectionnées)
 
 		filtrerDossiers()
     }
 
+    let activitésPrincipalesSet = new Set(activitésPrincipales)
+
+    $: activitésPrincipalesNonSélectionnées = activitésPrincipalesSet.difference(activitésPrincipalesSélectionnées)
+
     $: rememberTriFiltres(triSélectionné, {
         phases: phasesSélectionnées,
         'prochaine action attendue de': prochainesActionsAttenduesParSélectionnés,
-        instructeurs: instructeursSélectionnés
+        instructeurs: instructeursSélectionnés,
+        activitésPrincipales: activitésPrincipalesSélectionnées
     })
 
     // filtrage avec les filtres initiaux
@@ -341,6 +350,7 @@
                     <FiltreParmiOptions
                         titre="Filtrer par activité principale"
                         options={new Set(activitésPrincipales)}
+                        optionsSélectionnées={activitésPrincipalesSélectionnées}
                         mettreÀJourOptionsSélectionnées={filtrerParActivitéPrincipale}
                     />
                     <FiltreParmiOptions
@@ -360,36 +370,44 @@
                 </div>
 
                 <section class="filtres-actifs fr-mb-1w">
-                    {#if instructeursSélectionnés.size >= 1}
-                        <div class="fr-mb-1w">
-                            <span>Dossiers suivis par&nbsp;:</span>
-                            {#each [...instructeursSélectionnés] as instructeur}
+                    <div class="fr-mb-1w">
+                        <span>Dossiers suivis par&nbsp;:</span>
+                        {#each [...instructeursSélectionnés] as instructeur}
+                            <span class="fr-tag fr-tag--sm fr-mr-1w fr-mb-1v">
+                                {instructeur}
+                            </span>
+                        {/each}
+                    </div>
+
+                    <div class="fr-mb-1w">
+                        <span>Prochaine action attendue par&nbsp;:</span>
+                        {#each [...prochainesActionsAttenduesParSélectionnés] as prochaineActionAttenduePar}
+                            <span class="fr-tag fr-tag--sm fr-mr-1w fr-mb-1v">
+                                {prochaineActionAttenduePar}
+                            </span>
+                        {/each}
+                    </div>
+                    
+                    <div class="fr-mb-1w">
+                        <span>Activités principales&nbsp;:</span>
+                        {#if activitésPrincipalesNonSélectionnées.size === 0}
+                            <strong>Toutes</strong>
+                        {:else if activitésPrincipalesNonSélectionnées.size <= 4}
+                            <strong>Toutes sauf</strong>
+                            {#each [...activitésPrincipalesNonSélectionnées] as activitéPrincipale}
                                 <span class="fr-tag fr-tag--sm fr-mr-1w fr-mb-1v">
-                                    {instructeur}
+                                    {activitéPrincipale}
                                 </span>
                             {/each}
-                        </div>
-                    {/if}
-                    {#if prochainesActionsAttenduesParSélectionnés.size >= 1}
-                        <div class="fr-mb-1w">
-                            <span>Prochaine action attendue par&nbsp;:</span>
-                            {#each [...prochainesActionsAttenduesParSélectionnés] as prochaineActionAttenduePar}
-                                <span class="fr-tag fr-tag--sm fr-mr-1w fr-mb-1v">
-                                    {prochaineActionAttenduePar}
-                                </span>
-                            {/each}
-                        </div>
-                    {/if}
-                    {#if activitésPrincipalesSélectionnées.size >= 1}
-                        <div class="fr-mb-1w">
-                            <span>Activités principales&nbsp;:</span>
+                        {:else}
                             {#each [...activitésPrincipalesSélectionnées] as activitéPrincipale}
                                 <span class="fr-tag fr-tag--sm fr-mr-1w fr-mb-1v">
                                     {activitéPrincipale}
                                 </span>
                             {/each}
-                        </div>
-                    {/if}
+                        {/if}
+                    </div>
+                    
                     {#if texteÀChercher}
                         <div class="fr-mb-1w">
                             <span class="fr-tag fr-tag--sm fr-mr-1w fr-mb-1v">Texte cherché : {texteÀChercher}</span>

--- a/scripts/front-end/components/screens/SuiviInstruction.svelte
+++ b/scripts/front-end/components/screens/SuiviInstruction.svelte
@@ -18,7 +18,7 @@
     /** @import {DossierRésumé, DossierPhase, DossierProchaineActionAttenduePar} from '../../../types/API_Pitchou.ts' */
     /** @import {PitchouState} from '../../store.js' */
     /** @import {default as Personne} from '../../../types/database/public/Personne.ts' */
-    /** @import  { TriTableauSuiviDDEP } from '../../../types/interfaceUtilisateur.ts' */
+    /** @import { FiltresLocalStorage, TriTableauSuiviDDEP } from '../../../types/interfaceUtilisateur.ts' */
 
 
     /** @type {DossierRésumé[]} */
@@ -38,6 +38,9 @@
 
     /** @type {TriTableauSuiviDDEP['id'] | undefined} */
     export let triIdSélectionné = undefined;
+
+    /** @type {Partial<FiltresLocalStorage>} */
+    export let filtresSélectionnés = {};
 
     export let rememberTriFiltres;
 
@@ -96,8 +99,6 @@
     /** @type {TriTableauSuiviDDEP | undefined} */
     let triSélectionné = tris.find(t => t.id === triIdSélectionné) || triPriorisationPhaseProchaineAction[0]
 
-    $: rememberTriFiltres(triSélectionné)
-
 
     /** @type {Map<'département' | 'commune' | 'phase' | 'prochaine action attendue de' | 'texte' | 'suivis' | 'instructeurs' | 'activité principale', (d: DossierRésumé) => boolean>} */
     const tousLesFiltres = new Map()
@@ -121,11 +122,13 @@
     const phaseOptions = new Set([...phases])
 
     /** @type {Set<DossierPhase>} */
-    let phasesSélectionnées = new Set([
-        'Accompagnement amont',
-        'Étude recevabilité DDEP',
-        'Instruction'
-    ])
+    let phasesSélectionnées = filtresSélectionnés.phases ? 
+        new Set(filtresSélectionnés.phases) :
+        new Set([
+            'Accompagnement amont',
+            'Étude recevabilité DDEP',
+            'Instruction'
+        ])
 
     /**
      *
@@ -296,10 +299,16 @@
 		filtrerDossiers()
     }
 
+    $: rememberTriFiltres(triSélectionné, {
+        phases: phasesSélectionnées
+    })
+
     // filtrage avec les filtres initiaux
     onMount(async () => {
         filtrerDossiers()
 	});
+
+    
 </script>
 
 <Squelette {email} {erreurs}>

--- a/scripts/front-end/components/screens/SuiviInstruction.svelte
+++ b/scripts/front-end/components/screens/SuiviInstruction.svelte
@@ -250,7 +250,10 @@
     const instructeursOptions = new Set([email, AUCUN_INSTRUCTEUR, ...instructeurEmailOptions])
 
     /** @type {Set<NonNullable<Personne['email']> | AUCUN_INSTRUCTEUR>} */
-    let instructeursSélectionnés = new Set([email])
+    let instructeursSélectionnés = new Set(filtresSélectionnés.instructeurs ?
+        filtresSélectionnés.instructeurs :
+        [email]
+    )
 
     tousLesFiltres.set('instructeurs', dossier => {
         if(!relationSuivis)
@@ -303,7 +306,8 @@
 
     $: rememberTriFiltres(triSélectionné, {
         phases: phasesSélectionnées,
-        'prochaine action attendue de': prochainesActionsAttenduesParSélectionnés
+        'prochaine action attendue de': prochainesActionsAttenduesParSélectionnés,
+        instructeurs: instructeursSélectionnés
     })
 
     // filtrage avec les filtres initiaux

--- a/scripts/front-end/components/screens/SuiviInstruction.svelte
+++ b/scripts/front-end/components/screens/SuiviInstruction.svelte
@@ -32,8 +32,14 @@
 
     /** @type {NonNullable<ComponentProps<Squelette>['email']>} */
     export let email;
+    
     /** @type {ComponentProps<Squelette>['erreurs']} */
     export let erreurs;
+
+    /** @type {TriTableauSuiviDDEP['id'] | undefined} */
+    export let triIdSélectionné = undefined;
+
+    export let rememberTriFiltres;
 
     $: dossiersIdSuivisParAucunInstructeur = relationSuivis && (() => {
         // démarrer avec tous les ids
@@ -53,8 +59,45 @@
     let dossiersSelectionnés = []
     //$: console.log('dossiersSelectionnés', dossiersSelectionnés)
 
+    const trisActivitéPrincipale = [
+        { nom: "Trier de A à Z", trier(){ dossiersSelectionnés = trierDossiersParOrdreAlphabétiqueColonne(dossiersSelectionnés, "activité_principale") }, id: 'ActivitéPrincipale-AZ' },
+        { nom: "Trier de Z à A", trier(){ dossiersSelectionnés = trierDossiersParOrdreAlphabétiqueColonne(dossiersSelectionnés, "activité_principale").reverse()}, id: 'ActivitéPrincipale-ZA' },
+    ]
+
+    const trisNomProjet = [
+        { nom: "Trier de A à Z", trier(){ dossiersSelectionnés = trierDossiersParOrdreAlphabétiqueColonne(dossiersSelectionnés, "nom") }, id: 'NomProjet-AZ' },
+        { nom: "Trier de Z à A", trier(){ dossiersSelectionnés = trierDossiersParOrdreAlphabétiqueColonne(dossiersSelectionnés, "nom").reverse() }, id: 'NomProjet-ZA' },
+    ]
+
+    const trisLocalisation = [
+        { nom: "Trier de A à Z", trier(){ dossiersSelectionnés = trierDossiersParOrdreAlphabétiqueColonne(dossiersSelectionnés, "localisation") }, id: 'Localisation-AZ' },
+        { nom: "Trier de Z à A", trier(){ dossiersSelectionnés = trierDossiersParOrdreAlphabétiqueColonne(dossiersSelectionnés, "localisation").reverse() }, id: 'Localisation-ZA' },
+    ]
+
+    const trisDéposant = [
+        { nom: "Trier de A à Z", trier(){ dossiersSelectionnés = trierDossiersParOrdreAlphabétiqueColonne(dossiersSelectionnés, "déposant") }, id: 'Déposant-AZ' },
+        { nom: "Trier de Z à A", trier(){ dossiersSelectionnés = trierDossiersParOrdreAlphabétiqueColonne(dossiersSelectionnés, "déposant").reverse() }, id: 'Déposant-ZA' },
+    ]
+
+    const triPriorisationPhaseProchaineAction = [
+        { nom: "Prioriser", trier(){ dossiersSelectionnés = trierDossiersParPhaseProchaineAction(dossiersSelectionnés) }, id: 'Priorisation-PhaseAction' }
+    ]
+    
+    /** @type {TriTableauSuiviDDEP[]} */
+    const tris = [
+        ...trisActivitéPrincipale,
+        ...trisNomProjet,
+        ...trisLocalisation,
+        ...trisDéposant,
+        ...triPriorisationPhaseProchaineAction
+    ]
+
+    // Cette ligne doit être tolérante à ce que triIdSélectionné soit undefined ou n'importe quoi
     /** @type {TriTableauSuiviDDEP | undefined} */
-    let triSélectionné = undefined
+    let triSélectionné = tris.find(t => t.id === triIdSélectionné) || triPriorisationPhaseProchaineAction[0]
+
+    $: rememberTriFiltres(triSélectionné)
+
 
     /** @type {Map<'département' | 'commune' | 'phase' | 'prochaine action attendue de' | 'texte' | 'suivis' | 'instructeurs' | 'activité principale', (d: DossierRésumé) => boolean>} */
     const tousLesFiltres = new Map()
@@ -67,6 +110,7 @@
 		}
 
 		dossiersSelectionnés = nouveauxDossiersSélectionnés;
+
         if(triSélectionné){
             triSélectionné.trier()
         }
@@ -251,30 +295,6 @@
 
 		filtrerDossiers()
     }
-
-    const trisActivitéPrincipale = [
-        { nom: "Trier de A à Z", trier(){ dossiersSelectionnés = trierDossiersParOrdreAlphabétiqueColonne(dossiersSelectionnés, "activité_principale") }, },
-        { nom: "Trier de Z à A", trier(){ dossiersSelectionnés = trierDossiersParOrdreAlphabétiqueColonne(dossiersSelectionnés, "activité_principale").reverse()},  },
-    ]
-
-    const trisNomProjet = [
-        { nom: "Trier de A à Z", trier(){ dossiersSelectionnés = trierDossiersParOrdreAlphabétiqueColonne(dossiersSelectionnés, "nom") } },
-        { nom: "Trier de Z à A", trier(){ dossiersSelectionnés = trierDossiersParOrdreAlphabétiqueColonne(dossiersSelectionnés, "nom").reverse() } },
-    ]
-
-    const trisLocalisation = [
-        { nom: "Trier de A à Z", trier(){ dossiersSelectionnés = trierDossiersParOrdreAlphabétiqueColonne(dossiersSelectionnés, "localisation") } },
-        { nom: "Trier de Z à A", trier(){ dossiersSelectionnés = trierDossiersParOrdreAlphabétiqueColonne(dossiersSelectionnés, "localisation").reverse() } },
-    ]
-
-    const trisDéposant = [
-        { nom: "Trier de A à Z", trier(){ dossiersSelectionnés = trierDossiersParOrdreAlphabétiqueColonne(dossiersSelectionnés, "déposant") } },
-        { nom: "Trier de Z à A", trier(){ dossiersSelectionnés = trierDossiersParOrdreAlphabétiqueColonne(dossiersSelectionnés, "déposant").reverse() } },
-    ]
-
-    const triPriorisationPhaseProchaineAction = [
-        { nom: "Prioriser", trier(){ dossiersSelectionnés = trierDossiersParPhaseProchaineAction(dossiersSelectionnés) } }
-    ]
 
     // filtrage avec les filtres initiaux
     onMount(async () => {

--- a/scripts/front-end/routes/Accueil.js
+++ b/scripts/front-end/routes/Accueil.js
@@ -65,6 +65,7 @@ function mapStateToPropsSuiviInstruction(state){
                     phases: filtres.phases ? [...filtres.phases] : undefined,
                     'prochaine action attendue de': filtres['prochaine action attendue de'] ? [...filtres['prochaine action attendue de']] : undefined,
                     instructeurs: filtres.instructeurs ? [...filtres.instructeurs] : undefined,
+                    activitésPrincipales: filtres.activitésPrincipales ? [...filtres.activitésPrincipales] : undefined,
                 }
             })
         }

--- a/scripts/front-end/routes/Accueil.js
+++ b/scripts/front-end/routes/Accueil.js
@@ -56,14 +56,15 @@ function mapStateToPropsSuiviInstruction(state){
         /**
          * 
          * @param {TriTableauSuiviDDEP} tri 
-         * @param {FiltresLocalStorage} filtres 
+         * @param {Partial<FiltresLocalStorage>} filtres 
          */
         rememberTriFiltres(tri, filtres){
             remember(TRI_FILTRE_CLEF_LOCALSTORAGE, {
                 tri: tri.id,
                 filtres: {
                     phases: filtres.phases ? [...filtres.phases] : undefined,
-                    'prochaine action attendue de': filtres['prochaine action attendue de'] ? [...filtres['prochaine action attendue de']] : undefined
+                    'prochaine action attendue de': filtres['prochaine action attendue de'] ? [...filtres['prochaine action attendue de']] : undefined,
+                    instructeurs: filtres.instructeurs ? [...filtres.instructeurs] : undefined,
                 }
             })
         }

--- a/scripts/front-end/routes/Accueil.js
+++ b/scripts/front-end/routes/Accueil.js
@@ -1,5 +1,7 @@
 //@ts-check
 
+import remember from 'remember';
+
 import { replaceComponent } from '../routeComponentLifeCycle.js'
 import store from '../store.js'
 import { svelteTarget } from '../config.js'
@@ -11,11 +13,56 @@ import SqueletteContenuVide from '../components/SqueletteContenuVide.svelte';
 import { chargerDossiers, logout, secretFromURL } from '../actions/main.js';
 import showLoginByEmail from './montrerPageDAccueil.js';
 
+
+/** @import {ComponentProps} from 'svelte' */
 /** @import {PitchouState} from '../store.js' */
 /** @import {ChampDescriptor} from '../../types/démarches-simplifiées/schema.ts' */
 /** @import {DossierDemarcheSimplifiee88444} from '../../types/démarches-simplifiées/DémarcheSimplifiée88444.ts' */
-/** @import {ComponentProps} from 'svelte' */
+/** @import {TriTableauSuiviDDEP} from '../../types/interfaceUtilisateur.ts' */
 
+const TRI_FILTRE_CLEF_LOCALSTORAGE = 'tri-filtres-tableau-suivi'
+
+const trisFiltresSélectionnés = await remember(TRI_FILTRE_CLEF_LOCALSTORAGE)
+
+/**
+ * 
+ * @param {PitchouState} state 
+ * @returns {ComponentProps<SuiviInstruction>}
+ */
+function mapStateToPropsSuiviInstruction(state){
+    if(!state.schemaDS88444){
+        throw new TypeError('Schema 88444 manquant dans le store')
+    }
+
+    /** @type {ChampDescriptor[]} */
+    const schemaChamps = state.schemaDS88444.revision.champDescriptors
+
+    const activitésPrincipalesChamp = schemaChamps.find(champDescriptor => champDescriptor.label === "Activité principale")
+
+    const dossiersById = state.dossiersRésumés
+
+    // @ts-ignore
+    return {
+        ...mapStateToSqueletteProps(state),
+        dossiers: [...dossiersById.values()],
+        relationSuivis: state.relationSuivis,
+        /** @type {DossierDemarcheSimplifiee88444["Activité principale"][] | undefined} */
+        //@ts-expect-error TS ne sait pas que les activités principales possibles proviennent du schema
+        activitésPrincipales: activitésPrincipalesChamp?.options,
+        // @ts-ignore
+        triIdSélectionné: trisFiltresSélectionnés?.tri,
+        /**
+         * 
+         * @param {TriTableauSuiviDDEP} tri 
+         * @param {*} filtres 
+         */
+        rememberTriFiltres(tri, filtres){
+            remember(TRI_FILTRE_CLEF_LOCALSTORAGE, {
+                tri: tri.id
+            })
+        }
+    }
+} 
 
 
 export default async () => {
@@ -71,41 +118,13 @@ export default async () => {
                     })
                 }
             })
-
-        if(!store.state.schemaDS88444){
-            throw new TypeError('Schema 88444 manquant dans le store')
-        }
-
-        /** @type {ChampDescriptor[]} */
-        const schemaChamps = store.state.schemaDS88444.revision.champDescriptors
-
-        const activitésPrincipalesChamp = schemaChamps.find(champDescriptor => champDescriptor.label === "Activité principale")
-
-        /**
-         * 
-         * @param {PitchouState} state 
-         * @returns {ComponentProps<SuiviInstruction>}
-         */
-        function mapStateToProps(state){
-            const dossiersById = state.dossiersRésumés
-
-            // @ts-ignore
-            return {
-                ...mapStateToSqueletteProps(state),
-                dossiers: [...dossiersById.values()],
-                relationSuivis: state.relationSuivis,
-                /** @type {DossierDemarcheSimplifiee88444["Activité principale"][] | undefined} */
-                //@ts-expect-error TS ne sait pas que les activités principales possibles proviennent du schema
-                activitésPrincipales: activitésPrincipalesChamp?.options,
-            }
-        }    
         
         const suiviInstructeur = new SuiviInstruction({
             target: svelteTarget,
-            props: mapStateToProps(store.state)
+            props: mapStateToPropsSuiviInstruction(store.state)
         });
 
-        replaceComponent(suiviInstructeur, mapStateToProps)
+        replaceComponent(suiviInstructeur, mapStateToPropsSuiviInstruction)
 
     }
     else{

--- a/scripts/front-end/routes/Accueil.js
+++ b/scripts/front-end/routes/Accueil.js
@@ -62,7 +62,8 @@ function mapStateToPropsSuiviInstruction(state){
             remember(TRI_FILTRE_CLEF_LOCALSTORAGE, {
                 tri: tri.id,
                 filtres: {
-                    phases: [...filtres.phases]
+                    phases: filtres.phases ? [...filtres.phases] : undefined,
+                    'prochaine action attendue de': filtres['prochaine action attendue de'] ? [...filtres['prochaine action attendue de']] : undefined
                 }
             })
         }

--- a/scripts/front-end/routes/Accueil.js
+++ b/scripts/front-end/routes/Accueil.js
@@ -18,7 +18,7 @@ import showLoginByEmail from './montrerPageDAccueil.js';
 /** @import {PitchouState} from '../store.js' */
 /** @import {ChampDescriptor} from '../../types/démarches-simplifiées/schema.ts' */
 /** @import {DossierDemarcheSimplifiee88444} from '../../types/démarches-simplifiées/DémarcheSimplifiée88444.ts' */
-/** @import {TriTableauSuiviDDEP} from '../../types/interfaceUtilisateur.ts' */
+/** @import {FiltresLocalStorage, TriTableauSuiviDDEP} from '../../types/interfaceUtilisateur.ts' */
 
 const TRI_FILTRE_CLEF_LOCALSTORAGE = 'tri-filtres-tableau-suivi'
 
@@ -51,14 +51,19 @@ function mapStateToPropsSuiviInstruction(state){
         activitésPrincipales: activitésPrincipalesChamp?.options,
         // @ts-ignore
         triIdSélectionné: trisFiltresSélectionnés?.tri,
+        // @ts-ignore
+        filtresSélectionnés: trisFiltresSélectionnés?.filtres,
         /**
          * 
          * @param {TriTableauSuiviDDEP} tri 
-         * @param {*} filtres 
+         * @param {FiltresLocalStorage} filtres 
          */
         rememberTriFiltres(tri, filtres){
             remember(TRI_FILTRE_CLEF_LOCALSTORAGE, {
-                tri: tri.id
+                tri: tri.id,
+                filtres: {
+                    phases: [...filtres.phases]
+                }
             })
         }
     }

--- a/scripts/types/interfaceUtilisateur.ts
+++ b/scripts/types/interfaceUtilisateur.ts
@@ -1,4 +1,4 @@
-import { DossierPhase } from "./API_Pitchou"
+import { DossierPhase, DossierProchaineActionAttenduePar } from "./API_Pitchou"
 
 export type TriTableauSuiviDDEP = {
     id: string // identifiant sérialisable pour identifier le tri sélectionné dans le localStorage
@@ -8,4 +8,5 @@ export type TriTableauSuiviDDEP = {
 
 export type FiltresLocalStorage = {
     phases: DossierPhase[]
+    'prochaine action attendue de': DossierProchaineActionAttenduePar[]
 }

--- a/scripts/types/interfaceUtilisateur.ts
+++ b/scripts/types/interfaceUtilisateur.ts
@@ -1,0 +1,7 @@
+import { DossierRésumé } from "./API_Pitchou"
+
+export type TriTableauSuiviDDEP = {
+    id: string // identifiant sérialisable pour identifier le tri sélectionné dans le localStorage
+    nom: string // nom d'affichage dans l'interface utilisateur
+    trier: () => DossierRésumé[]
+}

--- a/scripts/types/interfaceUtilisateur.ts
+++ b/scripts/types/interfaceUtilisateur.ts
@@ -1,4 +1,5 @@
 import { DossierPhase, DossierProchaineActionAttenduePar } from "./API_Pitchou"
+import Personne from "./database/public/Personne"
 
 export type TriTableauSuiviDDEP = {
     id: string // identifiant sérialisable pour identifier le tri sélectionné dans le localStorage
@@ -9,4 +10,5 @@ export type TriTableauSuiviDDEP = {
 export type FiltresLocalStorage = {
     phases: DossierPhase[]
     'prochaine action attendue de': DossierProchaineActionAttenduePar[]
+    instructeurs: NonNullable<Personne['email']>
 }

--- a/scripts/types/interfaceUtilisateur.ts
+++ b/scripts/types/interfaceUtilisateur.ts
@@ -1,4 +1,5 @@
 import { DossierPhase, DossierProchaineActionAttenduePar } from "./API_Pitchou"
+import Dossier from "./database/public/Dossier"
 import Personne from "./database/public/Personne"
 
 export type TriTableauSuiviDDEP = {
@@ -10,5 +11,6 @@ export type TriTableauSuiviDDEP = {
 export type FiltresLocalStorage = {
     phases: DossierPhase[]
     'prochaine action attendue de': DossierProchaineActionAttenduePar[]
-    instructeurs: NonNullable<Personne['email']>
+    instructeurs: NonNullable<Personne['email']>[]
+    activitésPrincipales: NonNullable<Dossier['activité_principale']>[]
 }

--- a/scripts/types/interfaceUtilisateur.ts
+++ b/scripts/types/interfaceUtilisateur.ts
@@ -1,7 +1,5 @@
-import { DossierRésumé } from "./API_Pitchou"
-
 export type TriTableauSuiviDDEP = {
     id: string // identifiant sérialisable pour identifier le tri sélectionné dans le localStorage
     nom: string // nom d'affichage dans l'interface utilisateur
-    trier: () => DossierRésumé[]
+    trier: () => void
 }

--- a/scripts/types/interfaceUtilisateur.ts
+++ b/scripts/types/interfaceUtilisateur.ts
@@ -1,5 +1,11 @@
+import { DossierPhase } from "./API_Pitchou"
+
 export type TriTableauSuiviDDEP = {
     id: string // identifiant sérialisable pour identifier le tri sélectionné dans le localStorage
     nom: string // nom d'affichage dans l'interface utilisateur
     trier: () => void
+}
+
+export type FiltresLocalStorage = {
+    phases: DossierPhase[]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,7 +21,7 @@
       "skipLibCheck": true,
       "moduleResolution": "bundler",
       "target": "esnext",
-      "lib": ["es2023", "dom", "dom.iterable"],
+      "lib": ["esnext", "dom", "dom.iterable"],
       "downlevelIteration": true,
       "types": [],
       "noUnusedLocals": true,


### PR DESCRIPTION
Créée par-dessus #153 

Dans la foulée, j'ai corrigé des bugs de sélections de dossier dans le filtre des activités principales et dans le filtre des "prochaine action attendue de"

Dans la foulée, quand on clic ailleurs, les filtres se ferment directement (plutôt que d'avoir à le fermer à la main)