### PR TITLE
Correction url /résultats-synchronisation

### DIFF
--- a/scripts/front-end/actions/main.js
+++ b/scripts/front-end/actions/main.js
@@ -75,7 +75,7 @@ export function chargerSchemaDS88444() {
 
 export function chargerRésultatsSynchronisation(){
     // @ts-ignore
-    return json('résultats-synchronisation').then( (/** @type {RésultatSynchronisationDS88444[]} */ résultatsSync) => {
+    return json('/résultats-synchronisation').then( (/** @type {RésultatSynchronisationDS88444[]} */ résultatsSync) => {
         for(const r of résultatsSync){
             r.horodatage = new Date(r.horodatage)
         }


### PR DESCRIPTION
L'url sans `/` fonctionnait bien sur la page d'accueil, mais pas sur une page de dossier directe