### PR TITLE
Fix filtre prochaine action

### DIFF
--- a/scripts/front-end/components/screens/SuiviInstruction.svelte
+++ b/scripts/front-end/components/screens/SuiviInstruction.svelte
@@ -191,6 +191,9 @@
         filtrerDossiers()
     }
 
+    $: prochainesActionsAttenduesParNonSélectionnés = prochainesActionsAttenduesParOptions.difference(prochainesActionsAttenduesParSélectionnés)
+
+
     let texteÀChercher = ''
 
     /**
@@ -390,11 +393,22 @@
 
                     <div class="fr-mb-1w">
                         <span>Prochaine action attendue par&nbsp;:</span>
-                        {#each [...prochainesActionsAttenduesParSélectionnés] as prochaineActionAttenduePar}
-                            <span class="fr-tag fr-tag--sm fr-mr-1w fr-mb-1v">
-                                {prochaineActionAttenduePar}
-                            </span>
-                        {/each}
+                        {#if prochainesActionsAttenduesParNonSélectionnés.size === 0}
+                            <strong>Toutes options</strong>
+                        {:else if prochainesActionsAttenduesParNonSélectionnés.size <= 2}
+                            <strong>Toutes options sauf</strong>
+                            {#each [...prochainesActionsAttenduesParNonSélectionnés] as prochaineActionAttenduePar}
+                                <span class="fr-tag fr-tag--sm fr-mr-1w fr-mb-1v">
+                                    {prochaineActionAttenduePar}
+                                </span>
+                            {/each}
+                        {:else}
+                            {#each [...prochainesActionsAttenduesParSélectionnés] as prochaineActionAttenduePar}
+                                <span class="fr-tag fr-tag--sm fr-mr-1w fr-mb-1v">
+                                    {prochaineActionAttenduePar}
+                                </span>
+                            {/each}
+                        {/if}
                     </div>
                     
                     <div class="fr-mb-1w">

--- a/scripts/front-end/routes/Accueil.js
+++ b/scripts/front-end/routes/Accueil.js
@@ -22,7 +22,7 @@ import showLoginByEmail from './montrerPageDAccueil.js';
 
 const TRI_FILTRE_CLEF_LOCALSTORAGE = 'tri-filtres-tableau-suivi'
 
-const trisFiltresSélectionnés = await remember(TRI_FILTRE_CLEF_LOCALSTORAGE)
+let trisFiltresSélectionnés = await remember(TRI_FILTRE_CLEF_LOCALSTORAGE)
 
 /**
  * 
@@ -59,7 +59,7 @@ function mapStateToPropsSuiviInstruction(state){
          * @param {Partial<FiltresLocalStorage>} filtres 
          */
         rememberTriFiltres(tri, filtres){
-            remember(TRI_FILTRE_CLEF_LOCALSTORAGE, {
+            const nouveauxTrisFiltresSélectionnés = {
                 tri: tri.id,
                 filtres: {
                     phases: filtres.phases ? [...filtres.phases] : undefined,
@@ -67,7 +67,11 @@ function mapStateToPropsSuiviInstruction(state){
                     instructeurs: filtres.instructeurs ? [...filtres.instructeurs] : undefined,
                     activitésPrincipales: filtres.activitésPrincipales ? [...filtres.activitésPrincipales] : undefined,
                 }
-            })
+            }
+
+            remember(TRI_FILTRE_CLEF_LOCALSTORAGE, nouveauxTrisFiltresSélectionnés)
+
+            trisFiltresSélectionnés = nouveauxTrisFiltresSélectionnés
         }
     }
 } 


### PR DESCRIPTION
Quand on change les filtre, navigue vers un dossier et revient sur le tableau, les filtres étaient perdus

C'est du au fait qu'ils sont stockés en localStorage, mais pas récupérés pour être re-transmis dans les props

Cette PR corrige ça

Elle améliore aussi l'affichage des "prochaines actions attendues par" dans le même modèle que pour les activités principales