### PR TITLE
Correction mauvais commentaire dans tableau après tri

### DIFF
--- a/scripts/front-end/components/screens/SuiviInstruction.svelte
+++ b/scripts/front-end/components/screens/SuiviInstruction.svelte
@@ -494,7 +494,7 @@
                             communes, départements, régions,
                             activité_principale, rattaché_au_régime_ae,
                             enjeu_politique, enjeu_écologique, commentaire_enjeu,
-                            phase, prochaine_action_attendue_par }, i}
+                            phase, prochaine_action_attendue_par }, i (id)}
                                 <tr>
                                     <td>
                                         <a class="fr-btn voir-le-dossier fr-btn--sm fr-btn--icon-left fr-icon-eye-line fr-mb-1w" href={`/dossier/${id}`}>Voir le dossier</a>


### PR DESCRIPTION
C'était un problème de mauvaise utilisation de svelte
Une `key` n'était pas fournie dans le `each` de génération des lignes du tableau de suivi. Avec l'id comme key, ça marche direct