### PR TITLE
Fix sync dept code

### DIFF
--- a/outils/sync-démarches-simplifiées-88444.js
+++ b/outils/sync-démarches-simplifiées-88444.js
@@ -594,10 +594,10 @@ let synchronisationDossierDansGroupeInstructeur;
 
 if(dossiersDS.length >= 1){
     /** Synchronisation de l'information des dossiers suivis */
-    synchronisationSuiviDossier = synchroniserSuiviDossier(dossiersDS);
+    synchronisationSuiviDossier = synchroniserSuiviDossier(dossiersDS, laTransactionDeSynchronisationDS);
 
     /** Synchronisation de l'information de quel dossier appartient à quel groupe_instructeurs */
-    synchronisationDossierDansGroupeInstructeur = synchroniserDossierDansGroupeInstructeur(dossiersDS);
+    synchronisationDossierDansGroupeInstructeur = synchroniserDossierDansGroupeInstructeur(dossiersDS, laTransactionDeSynchronisationDS);
 }
 
 

--- a/outils/sync-démarches-simplifiées-88444.js
+++ b/outils/sync-démarches-simplifiées-88444.js
@@ -199,7 +199,7 @@ const dossiersPourSynchronisation = dossiersDS.map((
     }
     else{
         if(projetSitué === `d'un ou plusieurs départements` && champDépartements){
-            départements = [... new Set(champDépartements.rows.map(c => c.champs[0].departement.code))]
+            départements = [... new Set(champDépartements.rows.map(c => c.champs[0].departement?.code))]
         }
         else{
             if(projetSitué === `d'une ou plusieurs régions` && champRégions){

--- a/scripts/server/database/dossier.js
+++ b/scripts/server/database/dossier.js
@@ -277,6 +277,10 @@ export async function synchroniserDossierDansGroupeInstructeur(dossierDS, databa
         const dossierId = dossierNumberDSToId.get(String(number))
         const groupe_instructeursId =  groupeInstructeursLabelToId.get(label)
 
+        if(!groupe_instructeursId){
+            throw new Error(`groupe_instructeursId manquant pour groupe ${label}`)
+        }
+
         return {dossier: dossierId, groupe_instructeurs: groupe_instructeursId}
     })
     


### PR DESCRIPTION
Cette PR corrige 2 problèmes qui faisaient échouer la synchronisation DS : 
- quand un département n'est pas rempli dans le formulaire
- quand il y a un nouveau groupe d'instructeurs