### PR TITLE
Afficher des données complémentaires du dossier dans l'onglet Projet

### DIFF
--- a/scripts/front-end/actions/créerObjetCapDepuisURLs.js
+++ b/scripts/front-end/actions/créerObjetCapDepuisURLs.js
@@ -120,7 +120,7 @@ function wrapRecupérerDossierComplet(url){
     }
 
     /**
-     * 
+     * @description Récupère les données du dossier et les formatte.
      * @param {Dossier['id']} dossierId
      * @returns {Promise<DossierComplet>}
      */
@@ -134,6 +134,17 @@ function wrapRecupérerDossierComplet(url){
 
         if(!ret){
             throw new TypeError(`Aucun dossier trouvé avec id '${dossierId}'`)
+        }
+
+        // Formattage des dates
+        if (ret.date_début_intervention) {
+            ret.date_début_intervention = new Date(ret.date_début_intervention)
+        }
+        if (ret.date_fin_intervention) {
+            ret.date_fin_intervention = new Date(ret.date_fin_intervention)
+        }
+        if (ret.date_dépôt) {
+            ret.date_dépôt = new Date(ret.date_dépôt)
         }
 
         // Le contenu du fichier espèces impactées est disponible sous forme de string base64 dans le JSON

--- a/scripts/front-end/components/Dossier/DossierProjet.svelte
+++ b/scripts/front-end/components/Dossier/DossierProjet.svelte
@@ -51,7 +51,7 @@
         <h2>Informations du projet</h2>
         <p>
             <strong>Description&nbsp;:</strong>
-            {dossier.description && dossier.description.length > 0
+            {dossier.description && dossier.description.length >= 1
                 ? dossier.description
                 : "Non renseignée"}
         </p>
@@ -196,7 +196,7 @@
             <p>
                 <strong> Modes de capture&nbsp;:</strong>
                 {dossier.scientifique_mode_capture &&
-                dossier.scientifique_mode_capture.length
+                dossier.scientifique_mode_capture.length >= 1
                     ? dossier.scientifique_mode_capture.join(", ")
                     : "Non renseignées"}
             </p>
@@ -223,12 +223,12 @@
             </p>
             <p>
                 <strong> Intervenant.e.s&nbsp;: </strong>
-                {#if scientifiquesIntervenants}
+                {#if scientifiquesIntervenants && scientifiquesIntervenants.length >= 1}
                     {#each scientifiquesIntervenants as { nom_complet, qualification }}
                         {nom_complet} - {qualification}
                     {/each}
                 {:else}
-                    Non renseignés
+                    Non renseigné.e.s
                 {/if}
             </p>
             <p>

--- a/scripts/front-end/components/Dossier/DossierProjet.svelte
+++ b/scripts/front-end/components/Dossier/DossierProjet.svelte
@@ -8,6 +8,7 @@
   /** @import {DescriptionMenacesEspèces} from '../../../types/especes.d.ts' */
 
   /** @type {DossierComplet} */
+  // @ts-ignore
   export let dossier;
 
   const { number_demarches_simplifiées: numdos } = dossier;
@@ -30,8 +31,13 @@
   /** @type {ReturnType<créerEspècesGroupéesParImpact> | undefined} */
   let espècesImpactéesParActivité;
 
+  // @ts-ignore
   $: espècesImpactéesParActivité =
     espècesImpactées && espècesImpactées.then(créerEspècesGroupéesParImpact);
+
+  /** @type {{nom_complet:string,qualification:string}[]| undefined} */
+  // @ts-ignore
+  let scientifiquesIntervenants = dossier.scientifique_intervenants;
 </script>
 
 <section class="row">
@@ -82,7 +88,7 @@
     <p>
       <strong>Durée de l'intervention :</strong>
       {dossier.durée_intervention
-        ? dossier.durée_intervention + ' années'
+        ? dossier.durée_intervention + " années"
         : "Non renseignée"}
     </p>
 
@@ -169,57 +175,60 @@
     {/if}
 
     {#if dossier.scientifique_type_demande}
-    <h2>Données scientifiques</h2>
-    <h3>Type de demande</h3>
-    <p>{dossier.scientifique_type_demande.join(", ")}</p>
+      <h2>Données scientifiques</h2>
+      <h3>Type de demande</h3>
+      <p>{dossier.scientifique_type_demande.join(", ")}</p>
 
-    <h3>Protocole de suivi</h3>
-    <p>{dossier.scientifique_description_protocole_suivi ?? "Non renseigné"}</p>
+      <h3>Protocole de suivi</h3>
+      <p>
+        {dossier.scientifique_description_protocole_suivi ?? "Non renseigné"}
+      </p>
 
-    <h3>Méthodes</h3>
+      <h3>Méthodes</h3>
 
-    <p>
-      <strong> Modes de capture :</strong>
-      {dossier.scientifique_mode_capture &&
-      dossier.scientifique_mode_capture.length
-        ? dossier.scientifique_mode_capture.join(", ")
-        : "Non renseignées"}
-    </p>
-    <p>
-      <strong> Source lumineuse :</strong>
-      {dossier.scientifique_modalités_source_lumineuses ?? "Non renseignée"}
-    </p>
-    <p>
-      <strong> Marquage :</strong>
-      {dossier.scientifique_modalités_marquage ?? "Non renseigné"}
-    </p>
-    <p>
-      <strong> Transport :</strong>
-      {dossier.scientifique_modalités_transport ?? "Non renseigné"}
-    </p>
+      <p>
+        <strong> Modes de capture :</strong>
+        {dossier.scientifique_mode_capture &&
+        dossier.scientifique_mode_capture.length
+          ? dossier.scientifique_mode_capture.join(", ")
+          : "Non renseignées"}
+      </p>
+      <p>
+        <strong> Source lumineuse :</strong>
+        {dossier.scientifique_modalités_source_lumineuses ?? "Non renseignée"}
+      </p>
+      <p>
+        <strong> Marquage :</strong>
+        {dossier.scientifique_modalités_marquage ?? "Non renseigné"}
+      </p>
+      <p>
+        <strong> Transport :</strong>
+        {dossier.scientifique_modalités_transport ?? "Non renseigné"}
+      </p>
 
-    <h3>Périmètre et intervenant.e.s</h3>
-    <p>
-      <strong>
-        Périmètre :
-      </strong>{dossier.scientifique_périmètre_intervention ?? "Non renseigné"}
-    </p>
-    <p>
-      <strong> Intervenant.e.s : </strong>
-      {#if dossier.scientifique_intervenants && dossier.scientifique_intervenants!=[null]}
-        {#each dossier.scientifique_intervenants as {nom_complet,qualification}}
-         {nom_complet} - {qualification}
-        {/each}
-      {:else}
-        Non renseignés
-      {/if}
-    </p>
-    <p>
-      <strong>
-        Précisions :
-      </strong>{dossier.scientifique_précisions_autres_intervenants ??
-        "Non renseignées"}
-    </p>
+      <h3>Périmètre et intervenant.e.s</h3>
+      <p>
+        <strong>
+          Périmètre :
+        </strong>{dossier.scientifique_périmètre_intervention ??
+          "Non renseigné"}
+      </p>
+      <p>
+        <strong> Intervenant.e.s : </strong>
+        {#if scientifiquesIntervenants}
+          {#each scientifiquesIntervenants as { nom_complet, qualification }}
+            {nom_complet} - {qualification}
+          {/each}
+        {:else}
+          Non renseignés
+        {/if}
+      </p>
+      <p>
+        <strong>
+          Précisions :
+        </strong>{dossier.scientifique_précisions_autres_intervenants ??
+          "Non renseignées"}
+      </p>
     {/if}
   </section>
 

--- a/scripts/front-end/components/Dossier/DossierProjet.svelte
+++ b/scripts/front-end/components/Dossier/DossierProjet.svelte
@@ -3,6 +3,7 @@
     import DownloadButton from "../DownloadButton.svelte";
     import Loader from "../Loader.svelte";
     import { créerEspècesGroupéesParImpact } from "../../actions/créerEspècesGroupéesParImpact.js";
+    import { formatDateRelative } from "../../affichageDossier.js";
 
     /** @import {DossierComplet} from '../../../types/API_Pitchou.ts' */
     /** @import {DescriptionMenacesEspèces} from '../../../types/especes.d.ts' */
@@ -59,17 +60,10 @@
             <strong>Date de début :</strong>
             {#if dossier.date_début_intervention}
                 <time
-                    datetime={new Date(
-                        dossier.date_début_intervention,
-                    ).toISOString()}
+                    datetime={
+                        dossier.date_début_intervention.toISOString()}
                 >
-                    {new Date(
-                        dossier.date_début_intervention,
-                    ).toLocaleDateString("fr-FR", {
-                        day: "numeric",
-                        month: "long",
-                        year: "numeric",
-                    })}
+                    {formatDateRelative(dossier.date_début_intervention)}
                 </time>
             {:else}
                 Non renseignée
@@ -84,14 +78,7 @@
                         dossier.date_fin_intervention,
                     ).toISOString()}
                 >
-                    {new Date(dossier.date_fin_intervention).toLocaleDateString(
-                        "fr-FR",
-                        {
-                            day: "numeric",
-                            month: "long",
-                            year: "numeric",
-                        },
-                    )}
+                    {formatDateRelative(dossier.date_fin_intervention)}
                 </time>
             {:else}
                 Non renseignée

--- a/scripts/front-end/components/Dossier/DossierProjet.svelte
+++ b/scripts/front-end/components/Dossier/DossierProjet.svelte
@@ -50,14 +50,14 @@
     <section class="column">
         <h2>Informations du projet</h2>
         <p>
-            <strong>Description :</strong>
+            <strong>Description&nbsp;:</strong>
             {dossier.description && dossier.description.length > 0
                 ? dossier.description
                 : "Non renseignée"}
         </p>
 
         <p>
-            <strong>Date de début :</strong>
+            <strong>Date de début&nbsp;:</strong>
             {#if dossier.date_début_intervention}
                 <time datetime={dossier.date_début_intervention.toISOString()}>
                     {formatDateRelative(dossier.date_début_intervention)}
@@ -68,7 +68,7 @@
         </p>
 
         <p>
-            <strong>Date de fin :</strong>
+            <strong>Date de fin&nbsp;:</strong>
             {#if dossier.date_fin_intervention}
                 <time
                     datetime={new Date(
@@ -83,7 +83,7 @@
         </p>
 
         <p>
-            <strong>Durée de l'intervention :</strong>
+            <strong>Durée de l'intervention&nbsp;:</strong>
             {dossier.durée_intervention
                 ? dossier.durée_intervention + " années"
                 : "Non renseignée"}
@@ -157,7 +157,7 @@
             <!-- Cette section est amenée à disparatre avec la fin de la transmission des espèces via un lien -->
             <p>
                 Le pétitionnaire n'a pas encore transmis de fichier, mais il a
-                transmis ceci :
+                transmis ceci&nbsp;:
             </p>
 
             <pre>{dossier.espèces_protégées_concernées}</pre>
@@ -194,35 +194,35 @@
             <h3>Méthodes</h3>
 
             <p>
-                <strong> Modes de capture :</strong>
+                <strong> Modes de capture&nbsp;:</strong>
                 {dossier.scientifique_mode_capture &&
                 dossier.scientifique_mode_capture.length
                     ? dossier.scientifique_mode_capture.join(", ")
                     : "Non renseignées"}
             </p>
             <p>
-                <strong> Source lumineuse :</strong>
+                <strong> Source lumineuse&nbsp;:</strong>
                 {dossier.scientifique_modalités_source_lumineuses ??
                     "Non renseignée"}
             </p>
             <p>
-                <strong> Marquage :</strong>
+                <strong> Marquage&nbsp;:</strong>
                 {dossier.scientifique_modalités_marquage ?? "Non renseigné"}
             </p>
             <p>
-                <strong> Transport :</strong>
+                <strong> Transport&nbsp;:</strong>
                 {dossier.scientifique_modalités_transport ?? "Non renseigné"}
             </p>
 
             <h3>Périmètre et intervenant.e.s</h3>
             <p>
                 <strong>
-                    Périmètre :
+                    Périmètre&nbsp;:
                 </strong>{dossier.scientifique_périmètre_intervention ??
                     "Non renseigné"}
             </p>
             <p>
-                <strong> Intervenant.e.s : </strong>
+                <strong> Intervenant.e.s&nbsp;: </strong>
                 {#if scientifiquesIntervenants}
                     {#each scientifiquesIntervenants as { nom_complet, qualification }}
                         {nom_complet} - {qualification}
@@ -233,7 +233,7 @@
             </p>
             <p>
                 <strong>
-                    Précisions :
+                    Précisions&nbsp;:
                 </strong>{dossier.scientifique_précisions_autres_intervenants ??
                     "Non renseignées"}
             </p>

--- a/scripts/front-end/components/Dossier/DossierProjet.svelte
+++ b/scripts/front-end/components/Dossier/DossierProjet.svelte
@@ -59,10 +59,7 @@
         <p>
             <strong>Date de début :</strong>
             {#if dossier.date_début_intervention}
-                <time
-                    datetime={
-                        dossier.date_début_intervention.toISOString()}
-                >
+                <time datetime={dossier.date_début_intervention.toISOString()}>
                     {formatDateRelative(dossier.date_début_intervention)}
                 </time>
             {:else}
@@ -182,7 +179,11 @@
         {#if dossier.scientifique_type_demande}
             <h2>Données scientifiques</h2>
             <h3>Type de demande</h3>
-            <p>{dossier.scientifique_type_demande.join(", ")}</p>
+            <ul>
+                {#each dossier.scientifique_type_demande as typeDemande}
+                    <li>{typeDemande}</li>
+                {/each}
+            </ul>
 
             <h3>Protocole de suivi</h3>
             <p>

--- a/scripts/front-end/components/Dossier/DossierProjet.svelte
+++ b/scripts/front-end/components/Dossier/DossierProjet.svelte
@@ -1,146 +1,263 @@
 <script>
-    //@ts-check
-    import DownloadButton from '../DownloadButton.svelte';
-    import Loader from '../Loader.svelte';
-    import {créerEspècesGroupéesParImpact} from '../../actions/créerEspècesGroupéesParImpact.js'
-    
-    /** @import {DossierComplet} from '../../../types/API_Pitchou.ts' */
-    /** @import {DescriptionMenacesEspèces} from '../../../types/especes.d.ts' */
+  //@ts-check
+  import DownloadButton from "../DownloadButton.svelte";
+  import Loader from "../Loader.svelte";
+  import { créerEspècesGroupéesParImpact } from "../../actions/créerEspècesGroupéesParImpact.js";
 
-    /** @type {DossierComplet} */
-    export let dossier
+  /** @import {DossierComplet} from '../../../types/API_Pitchou.ts' */
+  /** @import {DescriptionMenacesEspèces} from '../../../types/especes.d.ts' */
 
-    const {number_demarches_simplifiées: numdos} = dossier
+  /** @type {DossierComplet} */
+  export let dossier;
 
+  const { number_demarches_simplifiées: numdos } = dossier;
 
-    function makeFileContentBlob() {
-        return new Blob(
-            // @ts-ignore
-            [dossier.espècesImpactées && dossier.espècesImpactées.contenu], 
-            {type: dossier.espècesImpactées && dossier.espècesImpactées.media_type}
-        )
-    }
+  function makeFileContentBlob() {
+    return new Blob(
+      // @ts-ignore
+      [dossier.espècesImpactées && dossier.espècesImpactées.contenu],
+      { type: dossier.espècesImpactées && dossier.espècesImpactées.media_type }
+    );
+  }
 
-    function makeFilename() {
-        return dossier.espècesImpactées?.nom || 'fichier'
-    }
+  function makeFilename() {
+    return dossier.espècesImpactées?.nom || "fichier";
+  }
 
-    /** @type {Promise<DescriptionMenacesEspèces> | undefined} */
-    export let espècesImpactées;
+  /** @type {Promise<DescriptionMenacesEspèces> | undefined} */
+  export let espècesImpactées;
 
-    /** @type {ReturnType<créerEspècesGroupéesParImpact> | undefined} */
-    let espècesImpactéesParActivité
+  /** @type {ReturnType<créerEspècesGroupéesParImpact> | undefined} */
+  let espècesImpactéesParActivité;
 
-    $: espècesImpactéesParActivité = espècesImpactées && espècesImpactées.then(créerEspècesGroupéesParImpact)
-    //.catch(err => console.error('err', err))
-
+  $: espècesImpactéesParActivité =
+    espècesImpactées && espècesImpactées.then(créerEspècesGroupéesParImpact);
 </script>
 
 <section class="row">
+  <section class="column">
+    <h2>Informations du projet</h2>
+    <p>
+      <strong>Description :</strong>
+      {dossier.description && dossier.description.length > 0
+        ? dossier.description
+        : "Non renseignée"}
+    </p>
 
-    <section>
-        <h2>Espèces impactées</h2>
-        {#if dossier.espècesImpactées}
-            <DownloadButton 
-                {makeFileContentBlob}
-                {makeFilename}
-                classname="fr-btn fr-btn--secondary"
-                label="Télécharger le fichier des espèces impactées"
-            ></DownloadButton>
+    <p>
+      <strong>Date de début :</strong>
+      {#if dossier.date_début_intervention}
+        <time
+          datetime={new Date(dossier.date_début_intervention).toISOString()}
+        >
+          {new Date(dossier.date_début_intervention).toLocaleDateString(
+            "fr-FR",
+            {
+              day: "numeric",
+              month: "long",
+              year: "numeric",
+            }
+          )}
+        </time>
+      {:else}
+        Non renseignée
+      {/if}
+    </p>
 
-            {#await espècesImpactéesParActivité}
-                <Loader></Loader>
-            {:then espècesImpactéesParActivité} 
-                {#if espècesImpactéesParActivité}
-                    {#each espècesImpactéesParActivité as {activité, espèces, impactsRésiduels}}
-                        <section class="liste-especes">
-                            <h3>{activité}</h3>
-                            <table class="fr-table">
-                                <thead>
-                                    <tr>
-                                        <th>Espèce</th>
-                                        {#if impactsRésiduels && impactsRésiduels.length >= 1}
-                                            {#each impactsRésiduels as nomColonne}
-                                                <th>{nomColonne}</th>
-                                            {/each}
-                                        {/if}
-                                    </tr>
-                                </thead>
-                                <tbody>
-                                    {#each espèces as {nomVernaculaire, nomScientifique, détails} }
-                                        <tr>
-                                            <td>{nomVernaculaire} (<i>{nomScientifique}</i>)</td>
-                                            {#each détails as détail}
-                                                <td>{détail}</td>
-                                            {/each}
-                                        </tr>
-                                    {/each}
-                                </tbody>
-                            </table>
-                        </section>
-                    {/each}
-                {/if}
-            {:catch erreur}
-                <div class="fr-alert fr-alert--error fr-mb-3w fr-mt-2w">
-                    {#if erreur.name === 'HTTPError'}
-                        Erreur de réception du fichier. Veuillez réessayer en rafraichissant la page maintenant ou plus tard.
-                    {:else if erreur.name === 'MediaTypeError'}
-                        Le fichier d'espèces impactées dans le dossier n'est pas d'un type qui permet de récupérer la liste des espèces.
-                        Un fichier <code>{erreur.attendu}</code> est attendu. Le fichier dans le dossier est de type <code>{erreur.obtenu}</code>.
-                        Vous pouvez demander au pétitionnaire de fournir le fichier dans le bon format à la place du fichier actuel.
-                    {:else}
-                        Une erreur est survenue. Veuillez réessayer en rafraichissant la page maintenant ou plus tard.
+    <p>
+      <strong>Date de fin :</strong>
+      {#if dossier.date_fin_intervention}
+        <time datetime={new Date(dossier.date_fin_intervention).toISOString()}>
+          {new Date(dossier.date_fin_intervention).toLocaleDateString("fr-FR", {
+            day: "numeric",
+            month: "long",
+            year: "numeric",
+          })}
+        </time>
+      {:else}
+        Non renseignée
+      {/if}
+    </p>
+
+    <p>
+      <strong>Durée de l'intervention :</strong>
+      {dossier.durée_intervention
+        ? dossier.durée_intervention
+        : "Non renseignée"}
+    </p>
+
+    <h2>Espèces impactées</h2>
+    {#if dossier.espècesImpactées}
+      <DownloadButton
+        {makeFileContentBlob}
+        {makeFilename}
+        classname="fr-btn fr-btn--secondary"
+        label="Télécharger le fichier des espèces impactées"
+      ></DownloadButton>
+
+      {#await espècesImpactéesParActivité}
+        <Loader></Loader>
+      {:then espècesImpactéesParActivité}
+        {#if espècesImpactéesParActivité}
+          {#each espècesImpactéesParActivité as { activité, espèces, impactsRésiduels }}
+            <section class="liste-especes">
+              <h3>{activité}</h3>
+              <table class="fr-table">
+                <thead>
+                  <tr>
+                    <th>Espèce</th>
+                    {#if impactsRésiduels && impactsRésiduels.length >= 1}
+                      {#each impactsRésiduels as nomColonne}
+                        <th>{nomColonne}</th>
+                      {/each}
                     {/if}
-                </div>
-            {/await}
-
-        {:else if dossier.espèces_protégées_concernées}
-            <!-- Cette section est amenée à disparatre avec la fin de la transmission des espèces via un lien -->
-            <p>Le pétitionnaire n'a pas encore transmis de fichier, mais il a transmis ceci :</p>
-            
-            <pre>{dossier.espèces_protégées_concernées}</pre>
-            <p>
-                <strong>Recommandation&nbsp;:</strong> l'inviter à plutôt transmettre 
-                <a href="/saisie-especes">un fichier qu'il peut créer sur Pitchou</a>,
-                puis déposer ce fichier au bon endroit sur son dossier sur Démarches Simplifiées
-            </p>
-        {:else}
-            <p>Aucune données sur les espèces impactées n'a été fournie par le pétitionnaire</p>
+                  </tr>
+                </thead>
+                <tbody>
+                  {#each espèces as { nomVernaculaire, nomScientifique, détails }}
+                    <tr>
+                      <td>{nomVernaculaire} (<i>{nomScientifique}</i>)</td>
+                      {#each détails as détail}
+                        <td>{détail}</td>
+                      {/each}
+                    </tr>
+                  {/each}
+                </tbody>
+              </table>
+            </section>
+          {/each}
         {/if}
-    </section>
+      {:catch erreur}
+        <div class="fr-alert fr-alert--error fr-mb-3w fr-mt-2w">
+          {#if erreur.name === "HTTPError"}
+            Erreur de réception du fichier. Veuillez réessayer en rafraichissant
+            la page maintenant ou plus tard.
+          {:else if erreur.name === "MediaTypeError"}
+            Le fichier d'espèces impactées dans le dossier n'est pas d'un type
+            qui permet de récupérer la liste des espèces. Un fichier <code
+              >{erreur.attendu}</code
+            >
+            est attendu. Le fichier dans le dossier est de type
+            <code>{erreur.obtenu}</code>. Vous pouvez demander au pétitionnaire
+            de fournir le fichier dans le bon format à la place du fichier
+            actuel.
+          {:else}
+            Une erreur est survenue. Veuillez réessayer en rafraichissant la
+            page maintenant ou plus tard.
+          {/if}
+        </div>
+      {/await}
+    {:else if dossier.espèces_protégées_concernées}
+      <!-- Cette section est amenée à disparatre avec la fin de la transmission des espèces via un lien -->
+      <p>
+        Le pétitionnaire n'a pas encore transmis de fichier, mais il a transmis
+        ceci :
+      </p>
 
-    <section>
-        <h2>Dossier déposé</h2>
-        <a class="fr-btn fr-mb-1w" target="_blank" href={`https://www.demarches-simplifiees.fr/procedures/88444/dossiers/${numdos}`}>Dossier sur Démarches Simplifiées</a>
-    </section>
+      <pre>{dossier.espèces_protégées_concernées}</pre>
+      <p>
+        <strong>Recommandation&nbsp;:</strong> l'inviter à plutôt transmettre
+        <a href="/saisie-especes">un fichier qu'il peut créer sur Pitchou</a>,
+        puis déposer ce fichier au bon endroit sur son dossier sur Démarches
+        Simplifiées
+      </p>
+    {:else}
+      <p>
+        Aucune données sur les espèces impactées n'a été fournie par le
+        pétitionnaire
+      </p>
+    {/if}
+
+    <h2>Données scientifiques</h2>
+    <h3>Type de demande</h3>
+    <p>{dossier.scientifique_type_demande?.join(", ") ?? "Non renseigné"}</p>
+
+    <h3>Protocole de suivi</h3>
+    <p>{dossier.scientifique_description_protocole_suivi ?? "Non renseigné"}</p>
+
+    <h3>Méthodes</h3>
+
+    <p>
+      <strong> Modes de capture :</strong>
+      {dossier.scientifique_mode_capture &&
+      dossier.scientifique_mode_capture.length
+        ? dossier.scientifique_mode_capture.join(", ")
+        : "Non renseignées"}
+    </p>
+    <p>
+      <strong> Source lumineuse :</strong>
+      {dossier.scientifique_modalités_source_lumineuses ?? "Non renseignée"}
+    </p>
+    <p>
+      <strong> Marquage :</strong>
+      {dossier.scientifique_modalités_marquage ?? "Non renseigné"}
+    </p>
+    <p>
+      <strong> Transport :</strong>
+      {dossier.scientifique_modalités_transport ?? "Non renseigné"}
+    </p>
+
+    <h3>Périmètre et intervenants</h3>
+    <p>
+      <strong>
+        Périmètre :
+      </strong>{dossier.scientifique_périmètre_intervention ?? "Non renseigné"}
+    </p>
+    <p>
+      <strong> Intervenants : </strong>{dossier.scientifique_intervenants ??
+        "Non renseignés"}
+    </p>
+    <p>
+      <strong>
+        Précisions :
+      </strong>{dossier.scientifique_précisions_autres_intervenants ??
+        "Non renseignées"}
+    </p>
+  </section>
+
+  <section>
+    <h2>Dossier déposé</h2>
+    <a
+      class="fr-btn fr-mb-1w"
+      target="_blank"
+      href={`https://www.demarches-simplifiees.fr/procedures/88444/dossiers/${numdos}`}
+      >Dossier sur Démarches Simplifiées</a
+    >
+  </section>
 </section>
 
 <style lang="scss">
+  .column {
+    h2 {
+      margin-top: 3rem;
+    }
+    & > :nth-child(1) {
+      margin-top: 0;
+    }
+  }
+  .row {
+    display: flex;
+    flex-direction: row;
 
-    .row{
-        display: flex;
-        flex-direction: row;
-
-        &>:nth-child(1){
-            flex: 3;
-        }
-
-        &>:nth-child(2){
-            flex: 2;
-        }
+    & > :nth-child(1) {
+      flex: 3;
     }
 
-    .liste-especes{
-        margin-top: 2rem;
-        margin-bottom: 2rem;
-
-        h3{
-            margin-bottom: 1rem;
-        }
+    & > :nth-child(2) {
+      flex: 2;
     }
+  }
 
+  .liste-especes {
+    margin-top: 2rem;
+    margin-bottom: 2rem;
 
-    pre{
-        white-space: pre-wrap;
+    h3 {
+      margin-bottom: 1rem;
     }
+  }
+
+  pre {
+    white-space: pre-wrap;
+  }
 </style>

--- a/scripts/front-end/components/Dossier/DossierProjet.svelte
+++ b/scripts/front-end/components/Dossier/DossierProjet.svelte
@@ -82,7 +82,7 @@
     <p>
       <strong>Durée de l'intervention :</strong>
       {dossier.durée_intervention
-        ? dossier.durée_intervention
+        ? dossier.durée_intervention + ' années'
         : "Non renseignée"}
     </p>
 
@@ -168,9 +168,10 @@
       </p>
     {/if}
 
+    {#if dossier.scientifique_type_demande}
     <h2>Données scientifiques</h2>
     <h3>Type de demande</h3>
-    <p>{dossier.scientifique_type_demande?.join(", ") ?? "Non renseigné"}</p>
+    <p>{dossier.scientifique_type_demande.join(", ")}</p>
 
     <h3>Protocole de suivi</h3>
     <p>{dossier.scientifique_description_protocole_suivi ?? "Non renseigné"}</p>
@@ -197,15 +198,21 @@
       {dossier.scientifique_modalités_transport ?? "Non renseigné"}
     </p>
 
-    <h3>Périmètre et intervenants</h3>
+    <h3>Périmètre et intervenant.e.s</h3>
     <p>
       <strong>
         Périmètre :
       </strong>{dossier.scientifique_périmètre_intervention ?? "Non renseigné"}
     </p>
     <p>
-      <strong> Intervenants : </strong>{dossier.scientifique_intervenants ??
-        "Non renseignés"}
+      <strong> Intervenant.e.s : </strong>
+      {#if dossier.scientifique_intervenants && dossier.scientifique_intervenants!=[null]}
+        {#each dossier.scientifique_intervenants as {nom_complet,qualification}}
+         {nom_complet} - {qualification}
+        {/each}
+      {:else}
+        Non renseignés
+      {/if}
     </p>
     <p>
       <strong>
@@ -213,6 +220,7 @@
       </strong>{dossier.scientifique_précisions_autres_intervenants ??
         "Non renseignées"}
     </p>
+    {/if}
   </section>
 
   <section>

--- a/scripts/front-end/components/Dossier/DossierProjet.svelte
+++ b/scripts/front-end/components/Dossier/DossierProjet.svelte
@@ -1,280 +1,300 @@
 <script>
-  //@ts-check
-  import DownloadButton from "../DownloadButton.svelte";
-  import Loader from "../Loader.svelte";
-  import { créerEspècesGroupéesParImpact } from "../../actions/créerEspècesGroupéesParImpact.js";
+    //@ts-check
+    import DownloadButton from "../DownloadButton.svelte";
+    import Loader from "../Loader.svelte";
+    import { créerEspècesGroupéesParImpact } from "../../actions/créerEspècesGroupéesParImpact.js";
 
-  /** @import {DossierComplet} from '../../../types/API_Pitchou.ts' */
-  /** @import {DescriptionMenacesEspèces} from '../../../types/especes.d.ts' */
+    /** @import {DossierComplet} from '../../../types/API_Pitchou.ts' */
+    /** @import {DescriptionMenacesEspèces} from '../../../types/especes.d.ts' */
 
-  /** @type {DossierComplet} */
-  // @ts-ignore
-  export let dossier;
+    /** @type {DossierComplet} */
+    // @ts-ignore
+    export let dossier;
 
-  const { number_demarches_simplifiées: numdos } = dossier;
+    const { number_demarches_simplifiées: numdos } = dossier;
 
-  function makeFileContentBlob() {
-    return new Blob(
-      // @ts-ignore
-      [dossier.espècesImpactées && dossier.espècesImpactées.contenu],
-      { type: dossier.espècesImpactées && dossier.espècesImpactées.media_type }
-    );
-  }
+    function makeFileContentBlob() {
+        return new Blob(
+            // @ts-ignore
+            [dossier.espècesImpactées && dossier.espècesImpactées.contenu],
+            {
+                type:
+                    dossier.espècesImpactées &&
+                    dossier.espècesImpactées.media_type,
+            },
+        );
+    }
 
-  function makeFilename() {
-    return dossier.espècesImpactées?.nom || "fichier";
-  }
+    function makeFilename() {
+        return dossier.espècesImpactées?.nom || "fichier";
+    }
 
-  /** @type {Promise<DescriptionMenacesEspèces> | undefined} */
-  export let espècesImpactées;
+    /** @type {Promise<DescriptionMenacesEspèces> | undefined} */
+    export let espècesImpactées;
 
-  /** @type {ReturnType<créerEspècesGroupéesParImpact> | undefined} */
-  let espècesImpactéesParActivité;
+    /** @type {ReturnType<créerEspècesGroupéesParImpact> | undefined} */
+    let espècesImpactéesParActivité;
 
-  // @ts-ignore
-  $: espècesImpactéesParActivité =
-    espècesImpactées && espècesImpactées.then(créerEspècesGroupéesParImpact);
+    // @ts-ignore
+    $: espècesImpactéesParActivité =
+        espècesImpactées &&
+        espècesImpactées.then(créerEspècesGroupéesParImpact);
 
-  /** @type {{nom_complet:string,qualification:string}[]| undefined} */
-  // @ts-ignore
-  let scientifiquesIntervenants = dossier.scientifique_intervenants;
+    /** @type {{nom_complet:string,qualification:string}[]| undefined} */
+    // @ts-ignore
+    let scientifiquesIntervenants = dossier.scientifique_intervenants;
 </script>
 
 <section class="row">
-  <section class="column">
-    <h2>Informations du projet</h2>
-    <p>
-      <strong>Description :</strong>
-      {dossier.description && dossier.description.length > 0
-        ? dossier.description
-        : "Non renseignée"}
-    </p>
+    <section class="column">
+        <h2>Informations du projet</h2>
+        <p>
+            <strong>Description :</strong>
+            {dossier.description && dossier.description.length > 0
+                ? dossier.description
+                : "Non renseignée"}
+        </p>
 
-    <p>
-      <strong>Date de début :</strong>
-      {#if dossier.date_début_intervention}
-        <time
-          datetime={new Date(dossier.date_début_intervention).toISOString()}
-        >
-          {new Date(dossier.date_début_intervention).toLocaleDateString(
-            "fr-FR",
-            {
-              day: "numeric",
-              month: "long",
-              year: "numeric",
-            }
-          )}
-        </time>
-      {:else}
-        Non renseignée
-      {/if}
-    </p>
+        <p>
+            <strong>Date de début :</strong>
+            {#if dossier.date_début_intervention}
+                <time
+                    datetime={new Date(
+                        dossier.date_début_intervention,
+                    ).toISOString()}
+                >
+                    {new Date(
+                        dossier.date_début_intervention,
+                    ).toLocaleDateString("fr-FR", {
+                        day: "numeric",
+                        month: "long",
+                        year: "numeric",
+                    })}
+                </time>
+            {:else}
+                Non renseignée
+            {/if}
+        </p>
 
-    <p>
-      <strong>Date de fin :</strong>
-      {#if dossier.date_fin_intervention}
-        <time datetime={new Date(dossier.date_fin_intervention).toISOString()}>
-          {new Date(dossier.date_fin_intervention).toLocaleDateString("fr-FR", {
-            day: "numeric",
-            month: "long",
-            year: "numeric",
-          })}
-        </time>
-      {:else}
-        Non renseignée
-      {/if}
-    </p>
+        <p>
+            <strong>Date de fin :</strong>
+            {#if dossier.date_fin_intervention}
+                <time
+                    datetime={new Date(
+                        dossier.date_fin_intervention,
+                    ).toISOString()}
+                >
+                    {new Date(dossier.date_fin_intervention).toLocaleDateString(
+                        "fr-FR",
+                        {
+                            day: "numeric",
+                            month: "long",
+                            year: "numeric",
+                        },
+                    )}
+                </time>
+            {:else}
+                Non renseignée
+            {/if}
+        </p>
 
-    <p>
-      <strong>Durée de l'intervention :</strong>
-      {dossier.durée_intervention
-        ? dossier.durée_intervention + " années"
-        : "Non renseignée"}
-    </p>
+        <p>
+            <strong>Durée de l'intervention :</strong>
+            {dossier.durée_intervention
+                ? dossier.durée_intervention + " années"
+                : "Non renseignée"}
+        </p>
 
-    <h2>Espèces impactées</h2>
-    {#if dossier.espècesImpactées}
-      <DownloadButton
-        {makeFileContentBlob}
-        {makeFilename}
-        classname="fr-btn fr-btn--secondary"
-        label="Télécharger le fichier des espèces impactées"
-      ></DownloadButton>
+        <h2>Espèces impactées</h2>
+        {#if dossier.espècesImpactées}
+            <DownloadButton
+                {makeFileContentBlob}
+                {makeFilename}
+                classname="fr-btn fr-btn--secondary"
+                label="Télécharger le fichier des espèces impactées"
+            ></DownloadButton>
 
-      {#await espècesImpactéesParActivité}
-        <Loader></Loader>
-      {:then espècesImpactéesParActivité}
-        {#if espècesImpactéesParActivité}
-          {#each espècesImpactéesParActivité as { activité, espèces, impactsRésiduels }}
-            <section class="liste-especes">
-              <h3>{activité}</h3>
-              <table class="fr-table">
-                <thead>
-                  <tr>
-                    <th>Espèce</th>
-                    {#if impactsRésiduels && impactsRésiduels.length >= 1}
-                      {#each impactsRésiduels as nomColonne}
-                        <th>{nomColonne}</th>
-                      {/each}
+            {#await espècesImpactéesParActivité}
+                <Loader></Loader>
+            {:then espècesImpactéesParActivité}
+                {#if espècesImpactéesParActivité}
+                    {#each espècesImpactéesParActivité as { activité, espèces, impactsRésiduels }}
+                        <section class="liste-especes">
+                            <h3>{activité}</h3>
+                            <table class="fr-table">
+                                <thead>
+                                    <tr>
+                                        <th>Espèce</th>
+                                        {#if impactsRésiduels && impactsRésiduels.length >= 1}
+                                            {#each impactsRésiduels as nomColonne}
+                                                <th>{nomColonne}</th>
+                                            {/each}
+                                        {/if}
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {#each espèces as { nomVernaculaire, nomScientifique, détails }}
+                                        <tr>
+                                            <td
+                                                >{nomVernaculaire} (<i
+                                                    >{nomScientifique}</i
+                                                >)</td
+                                            >
+                                            {#each détails as détail}
+                                                <td>{détail}</td>
+                                            {/each}
+                                        </tr>
+                                    {/each}
+                                </tbody>
+                            </table>
+                        </section>
+                    {/each}
+                {/if}
+            {:catch erreur}
+                <div class="fr-alert fr-alert--error fr-mb-3w fr-mt-2w">
+                    {#if erreur.name === "HTTPError"}
+                        Erreur de réception du fichier. Veuillez réessayer en
+                        rafraichissant la page maintenant ou plus tard.
+                    {:else if erreur.name === "MediaTypeError"}
+                        Le fichier d'espèces impactées dans le dossier n'est pas
+                        d'un type qui permet de récupérer la liste des espèces.
+                        Un fichier <code>{erreur.attendu}</code>
+                        est attendu. Le fichier dans le dossier est de type
+                        <code>{erreur.obtenu}</code>. Vous pouvez demander au
+                        pétitionnaire de fournir le fichier dans le bon format à
+                        la place du fichier actuel.
+                    {:else}
+                        Une erreur est survenue. Veuillez réessayer en
+                        rafraichissant la page maintenant ou plus tard.
                     {/if}
-                  </tr>
-                </thead>
-                <tbody>
-                  {#each espèces as { nomVernaculaire, nomScientifique, détails }}
-                    <tr>
-                      <td>{nomVernaculaire} (<i>{nomScientifique}</i>)</td>
-                      {#each détails as détail}
-                        <td>{détail}</td>
-                      {/each}
-                    </tr>
-                  {/each}
-                </tbody>
-              </table>
-            </section>
-          {/each}
-        {/if}
-      {:catch erreur}
-        <div class="fr-alert fr-alert--error fr-mb-3w fr-mt-2w">
-          {#if erreur.name === "HTTPError"}
-            Erreur de réception du fichier. Veuillez réessayer en rafraichissant
-            la page maintenant ou plus tard.
-          {:else if erreur.name === "MediaTypeError"}
-            Le fichier d'espèces impactées dans le dossier n'est pas d'un type
-            qui permet de récupérer la liste des espèces. Un fichier <code
-              >{erreur.attendu}</code
-            >
-            est attendu. Le fichier dans le dossier est de type
-            <code>{erreur.obtenu}</code>. Vous pouvez demander au pétitionnaire
-            de fournir le fichier dans le bon format à la place du fichier
-            actuel.
-          {:else}
-            Une erreur est survenue. Veuillez réessayer en rafraichissant la
-            page maintenant ou plus tard.
-          {/if}
-        </div>
-      {/await}
-    {:else if dossier.espèces_protégées_concernées}
-      <!-- Cette section est amenée à disparatre avec la fin de la transmission des espèces via un lien -->
-      <p>
-        Le pétitionnaire n'a pas encore transmis de fichier, mais il a transmis
-        ceci :
-      </p>
+                </div>
+            {/await}
+        {:else if dossier.espèces_protégées_concernées}
+            <!-- Cette section est amenée à disparatre avec la fin de la transmission des espèces via un lien -->
+            <p>
+                Le pétitionnaire n'a pas encore transmis de fichier, mais il a
+                transmis ceci :
+            </p>
 
-      <pre>{dossier.espèces_protégées_concernées}</pre>
-      <p>
-        <strong>Recommandation&nbsp;:</strong> l'inviter à plutôt transmettre
-        <a href="/saisie-especes">un fichier qu'il peut créer sur Pitchou</a>,
-        puis déposer ce fichier au bon endroit sur son dossier sur Démarches
-        Simplifiées
-      </p>
-    {:else}
-      <p>
-        Aucune données sur les espèces impactées n'a été fournie par le
-        pétitionnaire
-      </p>
-    {/if}
-
-    {#if dossier.scientifique_type_demande}
-      <h2>Données scientifiques</h2>
-      <h3>Type de demande</h3>
-      <p>{dossier.scientifique_type_demande.join(", ")}</p>
-
-      <h3>Protocole de suivi</h3>
-      <p>
-        {dossier.scientifique_description_protocole_suivi ?? "Non renseigné"}
-      </p>
-
-      <h3>Méthodes</h3>
-
-      <p>
-        <strong> Modes de capture :</strong>
-        {dossier.scientifique_mode_capture &&
-        dossier.scientifique_mode_capture.length
-          ? dossier.scientifique_mode_capture.join(", ")
-          : "Non renseignées"}
-      </p>
-      <p>
-        <strong> Source lumineuse :</strong>
-        {dossier.scientifique_modalités_source_lumineuses ?? "Non renseignée"}
-      </p>
-      <p>
-        <strong> Marquage :</strong>
-        {dossier.scientifique_modalités_marquage ?? "Non renseigné"}
-      </p>
-      <p>
-        <strong> Transport :</strong>
-        {dossier.scientifique_modalités_transport ?? "Non renseigné"}
-      </p>
-
-      <h3>Périmètre et intervenant.e.s</h3>
-      <p>
-        <strong>
-          Périmètre :
-        </strong>{dossier.scientifique_périmètre_intervention ??
-          "Non renseigné"}
-      </p>
-      <p>
-        <strong> Intervenant.e.s : </strong>
-        {#if scientifiquesIntervenants}
-          {#each scientifiquesIntervenants as { nom_complet, qualification }}
-            {nom_complet} - {qualification}
-          {/each}
+            <pre>{dossier.espèces_protégées_concernées}</pre>
+            <p>
+                <strong>Recommandation&nbsp;:</strong> l'inviter à plutôt
+                transmettre
+                <a href="/saisie-especes"
+                    >un fichier qu'il peut créer sur Pitchou</a
+                >, puis déposer ce fichier au bon endroit sur son dossier sur
+                Démarches Simplifiées
+            </p>
         {:else}
-          Non renseignés
+            <p>
+                Aucune données sur les espèces impactées n'a été fournie par le
+                pétitionnaire
+            </p>
         {/if}
-      </p>
-      <p>
-        <strong>
-          Précisions :
-        </strong>{dossier.scientifique_précisions_autres_intervenants ??
-          "Non renseignées"}
-      </p>
-    {/if}
-  </section>
 
-  <section>
-    <h2>Dossier déposé</h2>
-    <a
-      class="fr-btn fr-mb-1w"
-      target="_blank"
-      href={`https://www.demarches-simplifiees.fr/procedures/88444/dossiers/${numdos}`}
-      >Dossier sur Démarches Simplifiées</a
-    >
-  </section>
+        {#if dossier.scientifique_type_demande}
+            <h2>Données scientifiques</h2>
+            <h3>Type de demande</h3>
+            <p>{dossier.scientifique_type_demande.join(", ")}</p>
+
+            <h3>Protocole de suivi</h3>
+            <p>
+                {dossier.scientifique_description_protocole_suivi ??
+                    "Non renseigné"}
+            </p>
+
+            <h3>Méthodes</h3>
+
+            <p>
+                <strong> Modes de capture :</strong>
+                {dossier.scientifique_mode_capture &&
+                dossier.scientifique_mode_capture.length
+                    ? dossier.scientifique_mode_capture.join(", ")
+                    : "Non renseignées"}
+            </p>
+            <p>
+                <strong> Source lumineuse :</strong>
+                {dossier.scientifique_modalités_source_lumineuses ??
+                    "Non renseignée"}
+            </p>
+            <p>
+                <strong> Marquage :</strong>
+                {dossier.scientifique_modalités_marquage ?? "Non renseigné"}
+            </p>
+            <p>
+                <strong> Transport :</strong>
+                {dossier.scientifique_modalités_transport ?? "Non renseigné"}
+            </p>
+
+            <h3>Périmètre et intervenant.e.s</h3>
+            <p>
+                <strong>
+                    Périmètre :
+                </strong>{dossier.scientifique_périmètre_intervention ??
+                    "Non renseigné"}
+            </p>
+            <p>
+                <strong> Intervenant.e.s : </strong>
+                {#if scientifiquesIntervenants}
+                    {#each scientifiquesIntervenants as { nom_complet, qualification }}
+                        {nom_complet} - {qualification}
+                    {/each}
+                {:else}
+                    Non renseignés
+                {/if}
+            </p>
+            <p>
+                <strong>
+                    Précisions :
+                </strong>{dossier.scientifique_précisions_autres_intervenants ??
+                    "Non renseignées"}
+            </p>
+        {/if}
+    </section>
+
+    <section>
+        <h2>Dossier déposé</h2>
+        <a
+            class="fr-btn fr-mb-1w"
+            target="_blank"
+            href={`https://www.demarches-simplifiees.fr/procedures/88444/dossiers/${numdos}`}
+            >Dossier sur Démarches Simplifiées</a
+        >
+    </section>
 </section>
 
 <style lang="scss">
-  .column {
-    h2 {
-      margin-top: 3rem;
+    .column {
+        h2 {
+            margin-top: 3rem;
+        }
+        & > :nth-child(1) {
+            margin-top: 0;
+        }
     }
-    & > :nth-child(1) {
-      margin-top: 0;
+    .row {
+        display: flex;
+        flex-direction: row;
+
+        & > :nth-child(1) {
+            flex: 3;
+        }
+
+        & > :nth-child(2) {
+            flex: 2;
+        }
     }
-  }
-  .row {
-    display: flex;
-    flex-direction: row;
 
-    & > :nth-child(1) {
-      flex: 3;
+    .liste-especes {
+        margin-top: 2rem;
+        margin-bottom: 2rem;
+
+        h3 {
+            margin-bottom: 1rem;
+        }
     }
 
-    & > :nth-child(2) {
-      flex: 2;
+    pre {
+        white-space: pre-wrap;
     }
-  }
-
-  .liste-especes {
-    margin-top: 2rem;
-    margin-bottom: 2rem;
-
-    h3 {
-      margin-bottom: 1rem;
-    }
-  }
-
-  pre {
-    white-space: pre-wrap;
-  }
 </style>


### PR DESCRIPTION
Ajout des données suivantes :
Les données seraient à afficher dans l’onglet “Projet“ de l’interface Il s’agirait des champs suivants en base de données (table “dossier“) :
- description
- date_début_intervention
- date_fin_intervention
- date_début_intervention
- durée_intervention
- scientifique_type_demande
- scientifique_description_protocole_suivi
- scientifique_mode_capture
- scientifique_modalités_source_lumineuses
- scientifique_modalités_marquage
- scientifique_modalités_transport
- scientifique_périmètre_intervention
- scientifique_intervenants
- scientifique_précisions_autres_intervenants