### PR TITLE
Passer à traitement.event

### DIFF
--- a/scripts/server/database/dossier.js
+++ b/scripts/server/database/dossier.js
@@ -110,11 +110,14 @@ function traitementEventToDossierPhase(DSTraitementEvent){
  * @returns {Promise<any>}
  */
 export async function dumpDossierTraitements(idToTraitements, databaseConnection = directDatabaseConnection) {
+    console.log('dumpDossierTraitements', idToTraitements)
+
     /** @type {ÉvènementPhaseDossier[]} */
     const évènementsPhaseDossier = [];
     
     for(const [dossierId, apiTraitements] of idToTraitements){
-        for(const {dateTraitement, event, emailAgentTraitant, motivation} of apiTraitements){
+        for(const {dateTraitement, event, emailAgentTraitant, motivation, state} of apiTraitements){
+            console.log('traitement', dossierId, {dateTraitement, event, emailAgentTraitant, motivation, state})
             const phase = traitementEventToDossierPhase(event);
 
             if(phase){

--- a/scripts/types/démarches-simplifiées/apiSchema.ts
+++ b/scripts/types/démarches-simplifiées/apiSchema.ts
@@ -103,7 +103,12 @@ export interface Message{
 }
 
 export interface Traitement{
-    state: 'en_construction' | 'en_instruction' | 'accepte' | 'sans_suite' | 'refuse'
+    event: 'accepte' | 'accepte_automatiquement' | 
+        'classe_sans_suite' | 
+        'depose' | 'depose_correction_instructeur' | 'depose_correction_usager' | 
+        'passe_en_instruction' | 'passe_en_instruction_automatiquement' | 
+        'refuse' | 'refuse_automatiquement' | 
+        'repasse_en_construction' | 'repasse_en_instruction'
     emailAgentTraitant: string | null
     dateTraitement: string // représentant une date
     motivation: string | null


### PR DESCRIPTION
`Traitement.state` est sensé être déprécié

https://www.demarches-simplifiees.fr/graphql/schema/types/Traitement

Mais en testant, beaucoup de traitements n'ont pas de propriété `Traitement.event` pour remplacer

Je laisse la PR en draft jusqu'à avoir de la clarté de la part de l'équipe de DS