### PR TITLE
Amélioration première expérience tableau de suivi

### DIFF
--- a/scripts/front-end/components/screens/SuiviInstruction.svelte
+++ b/scripts/front-end/components/screens/SuiviInstruction.svelte
@@ -264,7 +264,7 @@
     /** @type {Set<NonNullable<Personne['email']> | AUCUN_INSTRUCTEUR>} */
     let instructeursSélectionnés = new Set(filtresSélectionnés.instructeurs ?
         filtresSélectionnés.instructeurs :
-        [email]
+        instructeursOptions
     )
 
     tousLesFiltres.set('instructeurs', dossier => {


### PR DESCRIPTION
Quand une instructrice va sur le tableau pour la première fois, elle voit tous les dossiers de son groupe instructeur (plutôt que ses dossiers suivis, sûrement vides, initialement)