### PR TITLE
mise à jour de svelte-preprocess à 6.0.3 pour silencier les warning de sass

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -57,7 +57,7 @@
         "simple-svelte-autocomplete": "^2.5.2",
         "svelte": "^4.2.19",
         "svelte-check": "^3.8.5",
-        "svelte-preprocess": "^5.1.3",
+        "svelte-preprocess": "^6.0.3",
         "typescript": "^5.8.3"
       },
       "engines": {
@@ -6251,7 +6251,7 @@
         "node": ">=8.10.0"
       }
     },
-    "node_modules/svelte-preprocess": {
+    "node_modules/svelte-check/node_modules/svelte-preprocess": {
       "version": "5.1.4",
       "resolved": "https://registry.npmjs.org/svelte-preprocess/-/svelte-preprocess-5.1.4.tgz",
       "integrity": "sha512-IvnbQ6D6Ao3Gg6ftiM5tdbR6aAETwjhHV+UKGf5bHGYR69RQvF1ho0JKPcbUON4vy4R7zom13jPjgdOWCQ5hDA==",
@@ -6280,6 +6280,62 @@
         "sugarss": "^2.0.0 || ^3.0.0 || ^4.0.0",
         "svelte": "^3.23.0 || ^4.0.0-next.0 || ^4.0.0 || ^5.0.0-next.0",
         "typescript": ">=3.9.5 || ^4.0.0 || ^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "coffeescript": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "postcss-load-config": {
+          "optional": true
+        },
+        "pug": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/svelte-preprocess": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/svelte-preprocess/-/svelte-preprocess-6.0.3.tgz",
+      "integrity": "sha512-PLG2k05qHdhmRG7zR/dyo5qKvakhm8IJ+hD2eFRQmMLHp7X3eJnjeupUtvuRpbNiF31RjVw45W+abDwHEmP5OA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.10.2",
+        "coffeescript": "^2.5.1",
+        "less": "^3.11.3 || ^4.0.0",
+        "postcss": "^7 || ^8",
+        "postcss-load-config": ">=3",
+        "pug": "^3.0.0",
+        "sass": "^1.26.8",
+        "stylus": ">=0.55",
+        "sugarss": "^2.0.0 || ^3.0.0 || ^4.0.0",
+        "svelte": "^4.0.0 || ^5.0.0-next.100 || ^5.0.0",
+        "typescript": "^5.0.0"
       },
       "peerDependenciesMeta": {
         "@babel/core": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "simple-svelte-autocomplete": "^2.5.2",
     "svelte": "^4.2.19",
     "svelte-check": "^3.8.5",
-    "svelte-preprocess": "^5.1.3",
+    "svelte-preprocess": "^6.0.3",
     "typescript": "^5.8.3"
   },
   "dependencies": {


### PR DESCRIPTION
entends-tu le calme ?

Fixes https://github.com/betagouv/pitchou/issues/251