### PR TITLE
Ajout d'un bouton pour suivre un dossier depuis le tableau de suivi et en-tête dossier

### DIFF
--- a/migrations/20250728133643_suivi-unique.js
+++ b/migrations/20250728133643_suivi-unique.js
@@ -1,0 +1,19 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export function up(knex) {
+    return knex.schema.alterTable('arête_personne_suit_dossier', (table) => {
+        table.unique(['dossier', 'personne'])
+    });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export function down(knex) {
+    return knex.schema.alterTable('arête_personne_suit_dossier', (table) => {
+        table.dropUnique(['dossier', 'personne'])
+    });
+};

--- a/scripts/front-end/actions/créerObjetCapDepuisURLs.js
+++ b/scripts/front-end/actions/créerObjetCapDepuisURLs.js
@@ -237,13 +237,13 @@ function wrapModifierDécisionAdministrative(url){
 /**
  * 
  * @param {string | undefined} url 
- * @returns {PitchouInstructeurCapabilities['changerRelationSuivi'] | undefined}
+ * @returns {PitchouInstructeurCapabilities['modifierRelationSuivi'] | undefined}
  */
-function wrapChangerRelationSuivi(url){
+function wrapModifierRelationSuivi(url){
     if(!url)
         return undefined
 
-    return function changerRelationSuivi(direction, personneEmail, dossierId){
+    return function modifierRelationSuivi(direction, personneEmail, dossierId){
 
         return text(url, {
             method: 'POST',
@@ -270,7 +270,7 @@ export default function(capURLs){
         listerDossiers: wrapGETUrl(capURLs.listerDossiers),
         recupérerDossierComplet: wrapRecupérerDossierComplet(capURLs.recupérerDossierComplet),
         listerRelationSuivi: wrapGETUrl(capURLs.listerRelationSuivi),
-        changerRelationSuivi: wrapChangerRelationSuivi(capURLs.changerRelationSuivi),
+        modifierRelationSuivi: wrapModifierRelationSuivi(capURLs.modifierRelationSuivi),
         listerÉvènementsPhaseDossier: wrapGETUrl(capURLs.listerÉvènementsPhaseDossier),
         listerMessages: wrapListerMessages(capURLs.listerMessages),
         modifierDossier: wrapModifierDossier(capURLs.modifierDossier),

--- a/scripts/front-end/actions/créerObjetCapDepuisURLs.js
+++ b/scripts/front-end/actions/créerObjetCapDepuisURLs.js
@@ -232,7 +232,7 @@ function wrapModifierDécisionAdministrative(url){
         body: JSON.stringify(args)
     })
 
-
+}
 
 /**
  * 

--- a/scripts/front-end/actions/créerObjetCapDepuisURLs.js
+++ b/scripts/front-end/actions/créerObjetCapDepuisURLs.js
@@ -231,6 +231,32 @@ function wrapModifierDécisionAdministrative(url){
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(args)
     })
+
+
+
+/**
+ * 
+ * @param {string | undefined} url 
+ * @returns {PitchouInstructeurCapabilities['changerRelationSuivi'] | undefined}
+ */
+function wrapChangerRelationSuivi(url){
+    if(!url)
+        return undefined
+
+    return function changerRelationSuivi(direction, personneEmail, dossierId){
+
+        return text(url, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                direction,
+                personneEmail,
+                dossierId
+            })
+        })
+        .then(() => undefined)
+
+    }
 }
 
 /**
@@ -244,6 +270,7 @@ export default function(capURLs){
         listerDossiers: wrapGETUrl(capURLs.listerDossiers),
         recupérerDossierComplet: wrapRecupérerDossierComplet(capURLs.recupérerDossierComplet),
         listerRelationSuivi: wrapGETUrl(capURLs.listerRelationSuivi),
+        changerRelationSuivi: wrapChangerRelationSuivi(capURLs.changerRelationSuivi),
         listerÉvènementsPhaseDossier: wrapGETUrl(capURLs.listerÉvènementsPhaseDossier),
         listerMessages: wrapListerMessages(capURLs.listerMessages),
         modifierDossier: wrapModifierDossier(capURLs.modifierDossier),

--- a/scripts/front-end/actions/main.js
+++ b/scripts/front-end/actions/main.js
@@ -15,8 +15,7 @@ import créerObjetCapDepuisURLs from './créerObjetCapDepuisURLs.js';
 
 const PITCHOU_SECRET_STORAGE_KEY = 'secret-pitchou'
 
-export function chargerDossiers(){
-
+export function chargerRelationSuivi(){
     if(store.state.capabilities?.listerRelationSuivi){
         store.state.capabilities?.listerRelationSuivi()
             .then(relationSuivisBDD => {
@@ -33,6 +32,12 @@ export function chargerDossiers(){
                 store.mutations.setRelationSuivis(relationSuivis)
             })
     }
+}
+
+
+export function chargerDossiers(){
+
+    chargerRelationSuivi()
 
     if(store.state.capabilities?.listerDossiers){
         return store.state.capabilities?.listerDossiers()

--- a/scripts/front-end/actions/suiviDossier.js
+++ b/scripts/front-end/actions/suiviDossier.js
@@ -1,19 +1,38 @@
 
+import store from '../store.js'
+
 /** @import Dossier from '../../types/database/public/Dossier.ts' */
 /** @import Personne from '../../types/database/public/Personne.ts' */
 
+//@ts-expect-error solution temporaire pour https://github.com/microsoft/TypeScript/issues/60908
+const inutile = true;
+
 /**
  * 
- * @param {NonNullable<Personne['email']>} instructeur 
- * @param {Dossier['id']} dossier 
+ * @param {NonNullable<Personne['email']>} instructeurEmail 
+ * @param {Dossier['id']} dossierId 
  */
-export function instructeurSuitDossier(instructeur, dossier){
-    const modifierSuivi = store.state.cap.modifierSuivi
+export function instructeurSuitDossier(instructeurEmail, dossierId){
+    const modifierRelationSuivi = store.state.capabilities.modifierRelationSuivi
 
-    if(!modifierSuivi){
-        throw new Error()
+    if(!modifierRelationSuivi){
+        throw new Error(`Pas les droits suffisants pour modifier une relation de suivi`)
     }
 
+    return modifierRelationSuivi("suivre", instructeurEmail, dossierId)
+}
 
-    throw `à continuer`
+/**
+ * 
+ * @param {NonNullable<Personne['email']>} instructeurEmail 
+ * @param {Dossier['id']} dossierId 
+ */
+export function instructeurLaisseDossier(instructeurEmail, dossierId){
+    const modifierRelationSuivi = store.state.capabilities.modifierRelationSuivi
+
+    if(!modifierRelationSuivi){
+        throw new Error(`Pas les droits suffisants pour modifier une relation de suivi`)
+    }
+
+    return modifierRelationSuivi("laisser", instructeurEmail, dossierId)
 }

--- a/scripts/front-end/actions/suiviDossier.js
+++ b/scripts/front-end/actions/suiviDossier.js
@@ -19,6 +19,12 @@ export function instructeurSuitDossier(instructeurEmail, dossierId){
         throw new Error(`Pas les droits suffisants pour modifier une relation de suivi`)
     }
 
+    const relationsSuivi = store.state.relationSuivis || new Map()
+    const dossiersSuivisParInstructeur = relationsSuivi.get(instructeurEmail) || new Set()
+    dossiersSuivisParInstructeur.add(dossierId)
+    relationsSuivi.set(instructeurEmail, dossiersSuivisParInstructeur)
+    store.mutations.setRelationSuivis(relationsSuivi)
+
     return modifierRelationSuivi("suivre", instructeurEmail, dossierId)
 }
 
@@ -33,6 +39,12 @@ export function instructeurLaisseDossier(instructeurEmail, dossierId){
     if(!modifierRelationSuivi){
         throw new Error(`Pas les droits suffisants pour modifier une relation de suivi`)
     }
+
+    const relationsSuivi = store.state.relationSuivis || new Map()
+    const dossiersSuivisParInstructeur = relationsSuivi.get(instructeurEmail) || new Set()
+    dossiersSuivisParInstructeur.delete(dossierId)
+    relationsSuivi.set(instructeurEmail, dossiersSuivisParInstructeur)
+    store.mutations.setRelationSuivis(relationsSuivi)
 
     return modifierRelationSuivi("laisser", instructeurEmail, dossierId)
 }

--- a/scripts/front-end/actions/suiviDossier.js
+++ b/scripts/front-end/actions/suiviDossier.js
@@ -1,0 +1,19 @@
+
+/** @import Dossier from '../../types/database/public/Dossier.ts' */
+/** @import Personne from '../../types/database/public/Personne.ts' */
+
+/**
+ * 
+ * @param {NonNullable<Personne['email']>} instructeur 
+ * @param {Dossier['id']} dossier 
+ */
+export function instructeurSuitDossier(instructeur, dossier){
+    const modifierSuivi = store.state.cap.modifierSuivi
+
+    if(!modifierSuivi){
+        throw new Error()
+    }
+
+
+    throw `à continuer`
+}

--- a/scripts/front-end/components/Dossier/EnteteDossier.svelte
+++ b/scripts/front-end/components/Dossier/EnteteDossier.svelte
@@ -1,15 +1,48 @@
 <script>
-    /** @import {DossierComplet} from '../../../types/API_Pitchou' */
 
     import {formatLocalisation, formatPorteurDeProjet} from '../../affichageDossier.js'
     import {afficherString} from '../../affichageValeurs.js'
     import TagPhase from '../TagPhase.svelte'
     import BoutonModale from '../DSFR/BoutonModale.svelte'
+    import {instructeurLaisseDossier, instructeurSuitDossier} from '../../actions/suiviDossier.js';
+    
+    /** @import {ComponentProps} from 'svelte' */
+    /** @import Squelette from '../Squelette.svelte' */
+
+    /** @import {DossierComplet} from '../../../types/API_Pitchou.ts' */
+    /** @import {PitchouState} from '../../store.js' */
+    /** @import Dossier from '../../../types/database/public/Dossier.ts' */
+
 
     /** @type {DossierComplet} */
     export let dossier
 
+    /** @type {NonNullable<ComponentProps<Squelette>['email']>} */
+    export let email
+
+    /** @type {PitchouState['relationSuivis']} */
+    export let relationSuivis
+
     let phase = dossier.évènementsPhase[0] && dossier.évènementsPhase[0].phase || 'Accompagnement amont';
+
+    $: dossiersSuiviParInstructeurActuel = relationSuivis && relationSuivis.get(email)
+    $: dossierActuelSuiviParInstructeurActuel = dossiersSuiviParInstructeurActuel && dossiersSuiviParInstructeurActuel.has(dossier.id)
+
+    /**
+     * 
+     * @param {Dossier['id']} id
+     */
+    function instructeurActuelSuitDossier(id) {
+        return instructeurSuitDossier(email, id)
+    }
+
+    /**
+     * 
+     * @param {Dossier['id']} id
+     */
+    function instructeurActuelLaisseDossier(id) {
+        return instructeurLaisseDossier(email, id)
+    }
 
 </script>
 
@@ -85,6 +118,16 @@
                 <span class="fr-icon-pantone-fill" aria-hidden="true"></span>
                 Autorisation environnementale
             </div>
+        {/if}
+
+        {#if typeof dossierActuelSuiviParInstructeurActuel === 'boolean'}
+
+            {#if dossierActuelSuiviParInstructeurActuel}
+                <button on:click={() => instructeurActuelLaisseDossier(dossier.id)} class="fr-btn fr-btn--secondary fr-btn--sm fr-icon-star-fill fr-btn--icon-left">Ne plus suivre</button>
+            {:else}
+                <button on:click={() => instructeurActuelSuitDossier(dossier.id)} class="fr-btn fr-btn--secondary fr-btn--sm fr-icon-star-line fr-btn--icon-left" >Suivre</button>
+            {/if}
+
         {/if}
 
         <!--

--- a/scripts/front-end/components/screens/Dossier.svelte
+++ b/scripts/front-end/components/screens/Dossier.svelte
@@ -16,11 +16,15 @@
     /** @import {ComponentProps} from 'svelte' */
     /** @import {DossierComplet} from '../../../types/API_Pitchou.ts' */
     /** @import {DescriptionMenacesEspèces} from '../../../types/especes.d.ts' */
+    /** @import {PitchouState} from '../../store.js' */
 
     /** @type {DossierComplet} */
     export let dossier
 
     $: console.info('Dossier complet', dossier)
+
+    /** @type {PitchouState['relationSuivis']} */
+    export let relationSuivis
 
 
     const EXTENSION_ATTENDUE = '.ods'
@@ -64,7 +68,7 @@
 <Squelette {email} {résultatsSynchronisationDS88444}>
     <div class="fr-grid-row fr-mt-2w">
         <div class="fr-col">
-            <EnteteDossier {dossier}></EnteteDossier>
+            <EnteteDossier {dossier} {relationSuivis} {email}></EnteteDossier>
             
             <div class="fr-tabs">
                 <ul class="fr-tabs__list" role="tablist" aria-label="[A modifier | nom du système d'onglet]">

--- a/scripts/front-end/components/screens/SuiviInstruction.svelte
+++ b/scripts/front-end/components/screens/SuiviInstruction.svelte
@@ -383,6 +383,14 @@
         }
     }
 
+
+    /**
+     * 
+     * @param {Dossier['id']} id
+     */
+    function instructeurActuelSuitDossier(id) {
+        
+    }
 </script>
 
 <Squelette {email} {erreurs} {résultatsSynchronisationDS88444}>
@@ -588,9 +596,9 @@
                                         {/if}
 
                                         {#if dossierIdsSuivisParInstructeurActuel.has(id)}
-                                            <button class="fr-btn fr-btn--secondary fr-btn--sm fr-icon-star-fill fr-btn--icon-left">Ne plus suivre</button>
+                                            <button on:click={() => instructeurActuelCesseDeSuivreDossier(id)} class="fr-btn fr-btn--secondary fr-btn--sm fr-icon-star-fill fr-btn--icon-left">Ne plus suivre</button>
                                         {:else}
-                                            <button class="fr-btn fr-btn--secondary fr-btn--sm fr-icon-star-line fr-btn--icon-left">Suivre</button>
+                                            <button on:click={() => instructeurActuelSuitDossier(id)} class="fr-btn fr-btn--secondary fr-btn--sm fr-icon-star-line fr-btn--icon-left" >Suivre</button>
                                         {/if}
 
                                     </td>

--- a/scripts/front-end/components/screens/SuiviInstruction.svelte
+++ b/scripts/front-end/components/screens/SuiviInstruction.svelte
@@ -588,9 +588,9 @@
                                         {/if}
 
                                         {#if dossierIdsSuivisParInstructeurActuel.has(id)}
-                                            <button class="fr-btn fr-btn--secondary fr-btn--sm fr-icon-star-line fr-btn--icon-left">Ne plus suivre</button>
+                                            <button class="fr-btn fr-btn--secondary fr-btn--sm fr-icon-star-fill fr-btn--icon-left">Ne plus suivre</button>
                                         {:else}
-                                            <button class="fr-btn fr-btn--secondary fr-btn--sm fr-icon-star-fill fr-btn--icon-left">Suivre</button>
+                                            <button class="fr-btn fr-btn--secondary fr-btn--sm fr-icon-star-line fr-btn--icon-left">Suivre</button>
                                         {/if}
 
                                     </td>

--- a/scripts/front-end/components/screens/SuiviInstruction.svelte
+++ b/scripts/front-end/components/screens/SuiviInstruction.svelte
@@ -19,6 +19,7 @@
     /** @import {DossierDemarcheSimplifiee88444} from '../../../types/démarches-simplifiées/DémarcheSimplifiée88444.ts'*/
     /** @import {DossierRésumé, DossierPhase, DossierProchaineActionAttenduePar} from '../../../types/API_Pitchou.ts' */
     /** @import {PitchouState} from '../../store.js' */
+    /** @import {default as Dossier} from '../../../types/database/public/Dossier.ts' */
     /** @import {default as Personne} from '../../../types/database/public/Personne.ts' */
     /** @import { FiltresLocalStorage, TriTableau } from '../../../types/interfaceUtilisateur.ts' */
 
@@ -70,6 +71,9 @@
     //$: console.log('dossiersNonSélectionnés', dossiersNonSélectionnés)
     //$: dossierNonSel = [...dossiersNonSélectionnés][0]
     //$: dossierNonSel && console.log('dossier non sélectionné', dossierNonSel, dossierNonSel.activité_principale, dossierNonSel.phase, dossierNonSel.prochaine_action_attendue_par)
+
+    /** @type {Set<Dossier['id']>} */
+    $: dossierIdsSuivisParInstructeurActuel = relationSuivis?.get(email) || new Set()
 
 
     const trisActivitéPrincipale = [
@@ -582,6 +586,13 @@
                                                 </div>
                                             </BoutonModale>
                                         {/if}
+
+                                        {#if dossierIdsSuivisParInstructeurActuel.has(id)}
+                                            <button class="fr-btn fr-btn--secondary fr-btn--sm fr-icon-star-line fr-btn--icon-left">Ne plus suivre</button>
+                                        {:else}
+                                            <button class="fr-btn fr-btn--secondary fr-btn--sm fr-icon-star-fill fr-btn--icon-left">Suivre</button>
+                                        {/if}
+
                                     </td>
                                     <td>{formatLocalisation({communes, départements, régions})}</td>
                                     <td>{activité_principale || ''}</td>

--- a/scripts/front-end/components/screens/SuiviInstruction.svelte
+++ b/scripts/front-end/components/screens/SuiviInstruction.svelte
@@ -14,6 +14,7 @@
     import {trouverDossiersIdCorrespondantsÀTexte} from '../../rechercherDansDossier.js'
     import {retirerAccents} from '../../../commun/manipulationStrings.js'
     import {trierDossiersParOrdreAlphabétiqueColonne, trierDossiersParPhaseProchaineAction} from '../../triDossiers.js'
+    import {instructeurLaisseDossier, instructeurSuitDossier} from '../../actions/suiviDossier.js';
     
     /** @import {ComponentProps} from 'svelte' */
     /** @import {DossierDemarcheSimplifiee88444} from '../../../types/démarches-simplifiées/DémarcheSimplifiée88444.ts'*/
@@ -389,8 +390,18 @@
      * @param {Dossier['id']} id
      */
     function instructeurActuelSuitDossier(id) {
-        
+        return instructeurSuitDossier(email, id)
     }
+
+    /**
+     * 
+     * @param {Dossier['id']} id
+     */
+    function instructeurActuelLaisseDossier(id) {
+        return instructeurLaisseDossier(email, id)
+    }
+
+    
 </script>
 
 <Squelette {email} {erreurs} {résultatsSynchronisationDS88444}>
@@ -596,7 +607,7 @@
                                         {/if}
 
                                         {#if dossierIdsSuivisParInstructeurActuel.has(id)}
-                                            <button on:click={() => instructeurActuelCesseDeSuivreDossier(id)} class="fr-btn fr-btn--secondary fr-btn--sm fr-icon-star-fill fr-btn--icon-left">Ne plus suivre</button>
+                                            <button on:click={() => instructeurActuelLaisseDossier(id)} class="fr-btn fr-btn--secondary fr-btn--sm fr-icon-star-fill fr-btn--icon-left">Ne plus suivre</button>
                                         {:else}
                                             <button on:click={() => instructeurActuelSuitDossier(id)} class="fr-btn fr-btn--secondary fr-btn--sm fr-icon-star-line fr-btn--icon-left" >Suivre</button>
                                         {/if}

--- a/scripts/front-end/routes/Dossier.js
+++ b/scripts/front-end/routes/Dossier.js
@@ -8,7 +8,9 @@ import { svelteTarget } from '../config.js'
 import { mapStateToSqueletteProps } from '../mapStateToSqueletteProps.js';
 import Dossier from '../components/screens/Dossier.svelte';
 import {getDossierComplet, chargerMessagesDossier} from '../actions/dossier.js'
+import {chargerRelationSuivi} from '../actions/main.js'
 
+/** @import {ComponentProps} from 'svelte' */
 
 /** @import {PitchouState} from '../store.js' */
 /** @import {DossierId} from '../../types/database/public/Dossier.ts' */
@@ -27,8 +29,9 @@ export default async ({params: {dossierId}}) => {
     // en attente de https://github.com/betagouv/pitchou/issues/154
     const messagesP = chargerMessagesDossier(id)
     const dossierP = getDossierComplet(id)
+    const relationSuiviP = chargerRelationSuivi()
 
-    const [dossier] = await Promise.all([dossierP, messagesP])
+    const [dossier] = await Promise.all([dossierP, messagesP, relationSuiviP])
 
 
     // TODO: expliquer que le dossier n'existe pas ?
@@ -37,7 +40,7 @@ export default async ({params: {dossierId}}) => {
     /**
      * 
      * @param {PitchouState} state
-     * @returns 
+     * @returns {ComponentProps<Dossier>}
      */
     function mapStateToProps(state){
         const dossier = state.dossiersComplets.get(id)
@@ -45,11 +48,14 @@ export default async ({params: {dossierId}}) => {
         if(!dossier) throw new TypeError(`Dossier avec id '${id}' manquant dans le store`)
 
         const messages = state.messagesParDossierId.get(id)
+        const relationSuivis = state.relationSuivis
 
+        // @ts-ignore
         return {
             ...mapStateToSqueletteProps(state),
             dossier,
-            messages
+            messages,
+            relationSuivis
         }
     }
     

--- a/scripts/server/database.js
+++ b/scripts/server/database.js
@@ -106,19 +106,21 @@ export async function getInstructeurCapBundleByPersonneCodeAccès(code_accès, d
     // de la capability que pour lister les dossiers
     const recupérerDossierCompletP = listerDossiersP
     const listerRelationSuiviP = listerDossiersP
+    const changerRelationSuiviP = listerDossiersP
     const listerÉvènementsPhaseDossierP = listerDossiersP
     const listerMessagesP = listerDossiersP
     const modifierDossierP = listerDossiersP
     const modifierDécisionAdministrativeDansDossierP = listerDossiersP
 
-    return Promise.all([remplirAnnotationsP, listerDossiersP, recupérerDossierCompletP, listerRelationSuiviP, listerÉvènementsPhaseDossierP, listerMessagesP, modifierDossierP, modifierDécisionAdministrativeDansDossierP, identitéP])
-        .then(([remplirAnnotations, listerDossiers, recupérerDossierComplet, listerRelationSuivi, listerÉvènementsPhaseDossier, listerMessages, modifierDossier, modifierDécisionAdministrativeDansDossier, identité]) => {
+    return Promise.all([remplirAnnotationsP, listerDossiersP, recupérerDossierCompletP, listerRelationSuiviP, changerRelationSuiviP, listerÉvènementsPhaseDossierP, listerMessagesP, modifierDossierP, modifierDécisionAdministrativeDansDossierP, identitéP])
+        .then(([remplirAnnotations, listerDossiers, recupérerDossierComplet, listerRelationSuivi, changerRelationSuivi, listerÉvènementsPhaseDossier, listerMessages, modifierDossier, modifierDécisionAdministrativeDansDossier, identité]) => {
             /** @type {Awaited<ReturnType<getInstructeurCapBundleByPersonneCodeAccès>>} */
             const ret = {
                 remplirAnnotations: undefined, 
                 listerDossiers,
                 recupérerDossierComplet,
                 listerRelationSuivi,
+                changerRelationSuivi,
                 listerÉvènementsPhaseDossier,
                 listerMessages, 
                 modifierDossier, 

--- a/scripts/server/database.js
+++ b/scripts/server/database.js
@@ -106,21 +106,21 @@ export async function getInstructeurCapBundleByPersonneCodeAccès(code_accès, d
     // de la capability que pour lister les dossiers
     const recupérerDossierCompletP = listerDossiersP
     const listerRelationSuiviP = listerDossiersP
-    const changerRelationSuiviP = listerDossiersP
+    const modifierRelationSuiviP = listerDossiersP
     const listerÉvènementsPhaseDossierP = listerDossiersP
     const listerMessagesP = listerDossiersP
     const modifierDossierP = listerDossiersP
     const modifierDécisionAdministrativeDansDossierP = listerDossiersP
 
-    return Promise.all([remplirAnnotationsP, listerDossiersP, recupérerDossierCompletP, listerRelationSuiviP, changerRelationSuiviP, listerÉvènementsPhaseDossierP, listerMessagesP, modifierDossierP, modifierDécisionAdministrativeDansDossierP, identitéP])
-        .then(([remplirAnnotations, listerDossiers, recupérerDossierComplet, listerRelationSuivi, changerRelationSuivi, listerÉvènementsPhaseDossier, listerMessages, modifierDossier, modifierDécisionAdministrativeDansDossier, identité]) => {
+    return Promise.all([remplirAnnotationsP, listerDossiersP, recupérerDossierCompletP, listerRelationSuiviP, modifierRelationSuiviP, listerÉvènementsPhaseDossierP, listerMessagesP, modifierDossierP, modifierDécisionAdministrativeDansDossierP, identitéP])
+        .then(([remplirAnnotations, listerDossiers, recupérerDossierComplet, listerRelationSuivi, modifierRelationSuivi, listerÉvènementsPhaseDossier, listerMessages, modifierDossier, modifierDécisionAdministrativeDansDossier, identité]) => {
             /** @type {Awaited<ReturnType<getInstructeurCapBundleByPersonneCodeAccès>>} */
             const ret = {
                 remplirAnnotations: undefined, 
                 listerDossiers,
                 recupérerDossierComplet,
                 listerRelationSuivi,
-                changerRelationSuivi,
+                modifierRelationSuivi,
                 listerÉvènementsPhaseDossier,
                 listerMessages, 
                 modifierDossier, 

--- a/scripts/server/database.js
+++ b/scripts/server/database.js
@@ -59,6 +59,10 @@ export function dumpEntreprises(entreprises){
 
 
 /**
+ * La table cap_écriture_annotation contient un instructeur_id qui est l'identifiant de l'instructeur
+ * dans démarches-simplifiées
+ * Cette fonction part de la capability d'écriture d'une annotation privée et retourne l'identifiant 
+ * d'instructeur (pour l'utiliser lors des appels API DS pour indiquer qui modifie une annotation privée)
  * 
  * @param {CapÉcritureAnnotation['cap']} cap 
  * @param {knex.Knex.Transaction | knex.Knex} [databaseConnection]

--- a/scripts/server/database/personne.js
+++ b/scripts/server/database/personne.js
@@ -2,10 +2,12 @@
 
 import {directDatabaseConnection} from '../database.js'
 
-//@ts-ignore
+/** @import {Knex} from 'knex' */
 /** @import {default as Personne, PersonneInitializer} from '../../types/database/public/Personne.ts' */
-//@ts-ignore
 /** @import {default as CapDossier} from '../../types/database/public/CapDossier.ts' */
+
+//@ts-expect-error solution temporaire pour https://github.com/microsoft/TypeScript/issues/60908
+const inutile = true;
 
 /**
  * @param {PersonneInitializer} personne
@@ -40,11 +42,12 @@ export function getPersonneByCode(code_accès) {
 /**
  *
  * @param {Personne['email']} email
+ * @param {Knex.Transaction | Knex} [databaseConnection]
  * @returns {Promise<Personne> | Promise<undefined>}
  */
-export function getPersonneByEmail(email) {
-    return directDatabaseConnection('personne')
-    .select()
+export function getPersonneByEmail(email, databaseConnection = directDatabaseConnection) {
+    return databaseConnection('personne')
+    .select('*')
     .where({ email })
     .first()
 }

--- a/scripts/server/database/relation_suivi.js
+++ b/scripts/server/database/relation_suivi.js
@@ -20,7 +20,7 @@ const inutile = true;
  */
 export function trouverRelationPersonneDepuisCap(cap, personneEmail, dossierId, databaseConnection = directDatabaseConnection){
     return databaseConnection('cap_dossier')
-        .select(['dossier.id as dossier_id', 'personne.id as personne_id'])
+        .select(['arête_groupe_instructeurs__dossier.dossier as dossier_id', 'personne.id as personne_id'])
         .leftJoin(
             'arête_cap_dossier__groupe_instructeurs',
             {'arête_cap_dossier__groupe_instructeurs.cap_dossier': 'cap_dossier.cap'}
@@ -36,7 +36,7 @@ export function trouverRelationPersonneDepuisCap(cap, personneEmail, dossierId, 
         .where({
             'cap_dossier.cap': cap,
             'personne.email': personneEmail, 
-            'dossier.id': dossierId
+            'arête_groupe_instructeurs__dossier.dossier': dossierId
         })
 }
 

--- a/scripts/server/database/relation_suivi.js
+++ b/scripts/server/database/relation_suivi.js
@@ -1,5 +1,4 @@
 import {directDatabaseConnection} from '../database.js'
-import {getPersonneByEmail} from './personne.js';
 
 /** @import {Knex} from 'knex' */
 /** @import CapDossier from '../../types/database/public/CapDossier.ts' */

--- a/scripts/server/database/relation_suivi.js
+++ b/scripts/server/database/relation_suivi.js
@@ -1,0 +1,78 @@
+import {directDatabaseConnection} from '../database.js'
+import {getPersonneByEmail} from './personne.js';
+
+/** @import {Knex} from 'knex' */
+/** @import CapDossier from '../../types/database/public/CapDossier.ts' */
+/** @import Dossier from '../../types/database/public/Dossier.ts' */
+/** @import Personne from '../../types/database/public/Personne.ts' */
+
+//@ts-expect-error solution temporaire pour https://github.com/microsoft/TypeScript/issues/60908
+const inutile = true;
+
+
+/**
+ * 
+ * @param {CapDossier['cap']} cap 
+ * @param {NonNullable<Personne['email']>} personneEmail 
+ * @param {Dossier['id']} dossierId 
+ * @param {Knex.Transaction | Knex} [databaseConnection]
+ * @return {Promise<any[]>}
+ */
+export function trouverRelationPersonneDepuisCap(cap, personneEmail, dossierId, databaseConnection = directDatabaseConnection){
+    return databaseConnection('cap_dossier')
+        .select(['dossier.id as dossier_id', 'personne.id as personne_id'])
+        .leftJoin(
+            'arête_cap_dossier__groupe_instructeurs',
+            {'arête_cap_dossier__groupe_instructeurs.cap_dossier': 'cap_dossier.cap'}
+        )
+        .leftJoin(
+            'arête_groupe_instructeurs__dossier', 
+            {'arête_groupe_instructeurs__dossier.groupe_instructeurs': 'arête_cap_dossier__groupe_instructeurs.groupe_instructeurs'}
+        )
+        .leftJoin(
+            'personne', 
+            {'personne.code_accès': 'cap_dossier.personne_cap'}
+        )
+        .where({
+            'cap_dossier.cap': cap,
+            'personne.email': personneEmail, 
+            'dossier.id': dossierId
+        })
+}
+
+
+/**
+ * 
+ * @param {Personne['id']} personneid 
+ * @param {Dossier['id']} dossierId 
+ * @param {Knex.Transaction | Knex} [databaseConnection]
+ * @return {Promise<void>}
+ */
+export async function instructeurSuitDossier(personneid, dossierId, databaseConnection = directDatabaseConnection){
+    return databaseConnection('arête_personne_suit_dossier')
+        .insert({
+            personne: personneid,
+            dossier: dossierId
+        })
+        .onConflict(['personne', 'dossier'])
+        .ignore() // ignorer si la personne suit déjà le dossier, parce que c'est le résultat final qui compte
+        .then(() => undefined)
+}
+
+
+/**
+ * 
+ * @param {Personne['id']} personneid 
+ * @param {Dossier['id']} dossierId 
+ * @param {Knex.Transaction | Knex} [databaseConnection]
+ * @return {Promise<void>}
+ */
+export async function instructeurLaisseDossier(personneid, dossierId, databaseConnection = directDatabaseConnection){
+    return databaseConnection('arête_personne_suit_dossier')
+        .delete()
+        .where({
+            personne: personneid,
+            dossier: dossierId
+        })
+        .then(() => undefined)
+}

--- a/scripts/server/main.js
+++ b/scripts/server/main.js
@@ -28,7 +28,7 @@ import { demanderLienPréremplissage } from './démarches-simplifiées/demanderL
 import remplirAnnotations from './démarches-simplifiées/remplirAnnotations.js'
 import _schema88444 from '../../data/démarches-simplifiées/schema-DS-88444.json' with {type: 'json'}
 import { chiffrerDonnéesSupplémentairesDossiers } from './démarches-simplifiées/chiffrerDéchiffrerDonnéesSupplémentaires.js'
-import {trouverRelationPersonneDepuisCap} from './database/relation_suivi.js'
+import {instructeurLaisseDossier, instructeurSuitDossier, trouverRelationPersonneDepuisCap} from './database/relation_suivi.js'
 
 
 /** @import {AnnotationsPriveesDemarcheSimplifiee88444, DossierDemarcheSimplifiee88444} from '../types/démarches-simplifiées/DémarcheSimplifiée88444.js' */
@@ -209,8 +209,8 @@ fastify.get('/caps', async function (request, reply) {
   if(capBundle.listerRelationSuivi){
     ret.listerRelationSuivi = `/dossiers/relation-suivis?cap=${capBundle.listerRelationSuivi}`
   }
-  if(capBundle.changerRelationSuivi){
-    ret.listerRelationSuivi = `/dossiers/relation-suivis?cap=${capBundle.changerRelationSuivi}`
+  if(capBundle.modifierRelationSuivi){
+    ret.modifierRelationSuivi = `/dossiers/relation-suivis?cap=${capBundle.modifierRelationSuivi}`
   }
   if(capBundle.listerÉvènementsPhaseDossier){
     ret.listerÉvènementsPhaseDossier = `/dossiers/evenements-phases?cap=${capBundle.listerÉvènementsPhaseDossier}`
@@ -597,7 +597,7 @@ fastify.post('/dossiers/relation-suivis', async function(request, reply) {
     return 
   }
 
-  /** @typedef {Parameters<PitchouInstructeurCapabilities['changerRelationSuivi']>} ChangerSuiviParams */
+  /** @typedef {Parameters<PitchouInstructeurCapabilities['modifierRelationSuivi']>} ChangerSuiviParams */
 
   /** @type { {direction: ChangerSuiviParams[0], personneEmail: ChangerSuiviParams[1], dossierId: ChangerSuiviParams[2]} } */
   // @ts-ignore
@@ -619,6 +619,7 @@ fastify.post('/dossiers/relation-suivis', async function(request, reply) {
   if(!personne){
       reply.code(400).send(`Pas de personne avec l'adresse email ${personneEmail}`)
       transaction.rollback()
+      return;
   }
 
   const personneId = personne.id
@@ -644,7 +645,6 @@ fastify.post('/dossiers/relation-suivis', async function(request, reply) {
       .catch((/** @type {any} */ err) => {
           reply.code(500).send(`Erreur lors du changement de suivi du dossier ${dossierId} par ${personneEmail}. ${err}`)
       })
-  })
 })
 
 

--- a/scripts/server/main.js
+++ b/scripts/server/main.js
@@ -13,7 +13,7 @@ import { closeDatabaseConnection, getInstructeurIdByÉcritureAnnotationCap,
   créerTransaction} from './database.js'
 
 import { dossiersAccessibleViaCap, getDossierComplet, getDossierMessages, getDossiersRésumésByCap, getÉvènementsPhaseDossiers, updateDossier } from './database/dossier.js'
-import { créerPersonneOuMettreÀJourCodeAccès, getPersonneByDossierCap } from './database/personne.js'
+import { créerPersonneOuMettreÀJourCodeAccès, getPersonneByDossierCap, getPersonneByEmail } from './database/personne.js'
 
 import { modifierDécisionAdministrative, supprimerDécisionAdministrative, ajouterDécisionAdministrativeAvecFichier } from './database/décision_administrative.js'
 import { ajouterPrescription, modifierPrescription, supprimerPrescription, ajouterPrescriptionsEtContrôles } from './database/prescription.js'
@@ -28,6 +28,7 @@ import { demanderLienPréremplissage } from './démarches-simplifiées/demanderL
 import remplirAnnotations from './démarches-simplifiées/remplirAnnotations.js'
 import _schema88444 from '../../data/démarches-simplifiées/schema-DS-88444.json' with {type: 'json'}
 import { chiffrerDonnéesSupplémentairesDossiers } from './démarches-simplifiées/chiffrerDéchiffrerDonnéesSupplémentaires.js'
+import {trouverRelationPersonneDepuisCap} from './database/relation_suivi.js'
 
 
 /** @import {AnnotationsPriveesDemarcheSimplifiee88444, DossierDemarcheSimplifiee88444} from '../types/démarches-simplifiées/DémarcheSimplifiée88444.js' */
@@ -207,6 +208,9 @@ fastify.get('/caps', async function (request, reply) {
   }
   if(capBundle.listerRelationSuivi){
     ret.listerRelationSuivi = `/dossiers/relation-suivis?cap=${capBundle.listerRelationSuivi}`
+  }
+  if(capBundle.changerRelationSuivi){
+    ret.listerRelationSuivi = `/dossiers/relation-suivis?cap=${capBundle.changerRelationSuivi}`
   }
   if(capBundle.listerÉvènementsPhaseDossier){
     ret.listerÉvènementsPhaseDossier = `/dossiers/evenements-phases?cap=${capBundle.listerÉvènementsPhaseDossier}`
@@ -581,6 +585,66 @@ fastify.get('/dossiers/relation-suivis', async function(request, reply) {
   } 
 
   return relationSuivis
+})
+
+
+fastify.post('/dossiers/relation-suivis', async function(request, reply) {
+  // @ts-ignore
+  const { cap } = request.query
+
+  if(!cap){
+    reply.code(400).send(`Paramètre 'cap' manquant dans l'URL`)
+    return 
+  }
+
+  /** @typedef {Parameters<PitchouInstructeurCapabilities['changerRelationSuivi']>} ChangerSuiviParams */
+
+  /** @type { {direction: ChangerSuiviParams[0], personneEmail: ChangerSuiviParams[1], dossierId: ChangerSuiviParams[2]} } */
+  // @ts-ignore
+  const {direction, personneEmail, dossierId} = request.body
+
+  const transaction = await créerTransaction()
+
+  const relationsSuiviViaCap = await trouverRelationPersonneDepuisCap(cap, personneEmail, dossierId, transaction)
+  console.log('relationsSuiviViaCap', relationsSuiviViaCap.length, relationsSuiviViaCap)
+
+  if(relationsSuiviViaCap.length === 0){
+    reply.code(403).send(`La capability ${cap} ne permet pas de modifier la relation de suivi entre instructeur.rice ${personneEmail} et dossier ${dossierId}`)
+    transaction.rollback()
+    return;
+  }
+
+  const personne = await getPersonneByEmail(personneEmail, transaction)
+
+  if(!personne){
+      reply.code(400).send(`Pas de personne avec l'adresse email ${personneEmail}`)
+      transaction.rollback()
+  }
+
+  const personneId = personne.id
+
+  let ret;
+
+  if(direction === 'suivre'){
+    ret = instructeurSuitDossier(personneId, dossierId, transaction)
+  }
+  else{
+    if(direction !== 'laisser'){
+      reply.code(500).send(`Erreur lors du changement de suivi du dossier. Direction ${direction} non reconnue.`)
+      return
+    }
+
+    ret = instructeurLaisseDossier(personneId, dossierId, transaction)
+  }
+
+  return ret
+      .then(() => transaction.commit())
+      .then(() => reply.send())
+      .catch((/** @type {any} */ err) => {transaction.rollback(); throw err})
+      .catch((/** @type {any} */ err) => {
+          reply.code(500).send(`Erreur lors du changement de suivi du dossier ${dossierId} par ${personneEmail}. ${err}`)
+      })
+  })
 })
 
 

--- a/scripts/types/capabilities.ts
+++ b/scripts/types/capabilities.ts
@@ -1,14 +1,16 @@
 import { DossierComplet, DossierRésumé, DécisionAdministrativePourTransfer } from "../types/API_Pitchou.ts"
+import Dossier from "./database/public/Dossier.ts"
 import Personne from "./database/public/Personne.ts"
 import Message from "./database/public/Message.ts"
 
 export interface PitchouInstructeurCapabilities{
     listerDossiers: () => Promise<DossierRésumé[]>
     recupérerDossierComplet: (dossierId: DossierComplet['id']) => Promise<DossierComplet>
-    listerRelationSuivi: () => Promise<{personneEmail: Personne['email'], dossiersSuivisIds: DossierRésumé['id'][]}[]>
+    listerRelationSuivi: () => Promise<{personneEmail: Personne['email'], dossiersSuivisIds: Dossier['id'][]}[]>
+    changerRelationSuivi: (direction: 'suivre' | 'laisser', personneEmail: NonNullable<Personne['email']>, dossierId: Dossier['id']) => Promise<void>
     listerMessages: (dossierId: DossierRésumé['id']) => Promise<Message[]>
     listerÉvènementsPhaseDossier: () => Promise<any[]>
-    modifierDossier: (dossierId: DossierRésumé['id'], dossier: Partial<DossierComplet>) => Promise<void> 
+    modifierDossier: (dossierId: Dossier['id'], dossier: Partial<DossierComplet>) => Promise<void> 
     remplirAnnotations: (annotations: any) => Promise<void>
     modifierDécisionAdministrativeDansDossier: (décisionAdministrative: DécisionAdministrativePourTransfer) => Promise<void> 
 }

--- a/scripts/types/capabilities.ts
+++ b/scripts/types/capabilities.ts
@@ -7,7 +7,7 @@ export interface PitchouInstructeurCapabilities{
     listerDossiers: () => Promise<DossierRésumé[]>
     recupérerDossierComplet: (dossierId: DossierComplet['id']) => Promise<DossierComplet>
     listerRelationSuivi: () => Promise<{personneEmail: Personne['email'], dossiersSuivisIds: Dossier['id'][]}[]>
-    changerRelationSuivi: (direction: 'suivre' | 'laisser', personneEmail: NonNullable<Personne['email']>, dossierId: Dossier['id']) => Promise<void>
+    modifierRelationSuivi: (direction: 'suivre' | 'laisser', personneEmail: NonNullable<Personne['email']>, dossierId: Dossier['id']) => Promise<void>
     listerMessages: (dossierId: DossierRésumé['id']) => Promise<Message[]>
     listerÉvènementsPhaseDossier: () => Promise<any[]>
     modifierDossier: (dossierId: Dossier['id'], dossier: Partial<DossierComplet>) => Promise<void> 


### PR DESCRIPTION
On peut suivre un dossier depuis le tableau de suivi et depuis un dossier

Je ferai l'affectation d'un dossier dans une PR séparée parce que celle-ci est déjà assez grosse