### PR TITLE
Créer composant déplier

### DIFF
--- a/scripts/front-end/components/Dossier/Contrôles/Prescription.svelte
+++ b/scripts/front-end/components/Dossier/Contrôles/Prescription.svelte
@@ -1,5 +1,6 @@
 <script>
     import FormulaireContrôle from './FormulaireContrôle.svelte'
+    import DéplierReplier from '../../common/DéplierReplier.svelte'
 
     import {formatDateRelative, formatDateAbsolue} from '../../../affichageDossier.js'
     import {ajouterContrôle as envoyerContrôle, modifierContrôle, supprimerContrôle} from '../../../actions/contrôle.js'
@@ -113,122 +114,123 @@
 </script>
 
 <section class="prescription-consultée">
-    <h6>
-        {description} 
-        {#if numéro_article}
-        - 
-        <small><strong>Numéro article&nbsp;:&nbsp;</strong>
-            {numéro_article}
-        </small>
-        {/if}
-    </h6>
-    <p></p>
-    <p><strong>Date d'échéance&nbsp;:</strong>
-        {#if date_échéance}
-            <time datetime={date_échéance?.toISOString()}>{formatDateRelative(date_échéance)}</time>
-        {:else}
-            {NON_RENSEIGNÉ}
-        {/if}
-    </p>
-    {#if surface_évitée || surface_compensée || 
-        individus_évités || surface_compensée || 
-        nids_évités || nids_compensés}
-        <p class="impacts-quantifiés">
-            {#if surface_évitée}<span><strong>Surface évitée&nbsp;:</strong> {surface_évitée}m²</span>{/if}
-            {#if surface_compensée}<span><strong>Surface compensée&nbsp;:</strong> {surface_compensée}m²</span>{/if}
-            {#if individus_évités}<span><strong>Individus évités&nbsp;:</strong> {individus_évités}</span>{/if}
-            {#if individus_compensés}<span><strong>Individus compensés&nbsp;:</strong> {individus_compensés}</span>{/if}
-            {#if nids_évités}<span><strong>Nids évités&nbsp;:</strong> {nids_évités}</span>{/if}
-            {#if nids_compensés}<span><strong>Nids compensés&nbsp;:</strong> {nids_compensés}</span>{/if}
-        </p>
-    {/if}
+    <DéplierReplier>
+        <h6 slot="summary">
+            {description} 
+        </h6>
+        <section slot="content">
+            {#if numéro_article}
+            <p><strong>Numéro article&nbsp;:&nbsp;</strong>{numéro_article}</p>
+            {/if}
+            <p><strong>Date d'échéance&nbsp;:</strong>
+                {#if date_échéance}
+                    <time datetime={date_échéance?.toISOString()}>{formatDateRelative(date_échéance)}</time>
+                {:else}
+                    {NON_RENSEIGNÉ}
+                {/if}
+            </p>
 
-    {#if contrôlesOuverts}
-    <button class="contrôles fr-btn fr-btn--secondary fr-btn--icon-left fr-icon-survey-line" 
-        on:click={() => fermerContrôles()}>
-        Fermer contrôles
-    </button>
-    {:else}
-    <button class="contrôles fr-btn fr-btn--secondary fr-btn--icon-left fr-icon-survey-line" 
-        on:click={() => ouvrirContrôles()}>
-        Ouvrir contrôles
-    </button>
-    {/if}
-
-    {#if contrôlesOuverts}
-        <section class="contrôles">
-            <h6>{#if contrôles.size === 1}1 contrôle{:else}{contrôles.size} contrôles {/if}</h6>
-
-            <button class="fr-btn fr-btn--icon-left fr-icon-add-line" on:click={ajouterContrôle}>
-                Ajouter un contrôle
-            </button>
-
-            {#if contrôleEnCours}
-                <FormulaireContrôle contrôle={contrôleEnCours} onValider={créerContrôle}>
-                    <button slot="bouton-valider" type="submit" class="fr-btn fr-btn--icon-left fr-icon-check-line">
-                        Finir le contrôle
-                    </button>
-                    <button
-                        slot="bouton-annuler"
-                        type="button"
-                        class="fr-btn fr-btn--secondary"
-                        on:click={() => (contrôleEnCours = undefined)}
-                    >
-                        Fermer le contrôle sans sauvegarder
-                    </button>
-                </FormulaireContrôle>
+            {#if surface_évitée || surface_compensée || 
+                individus_évités || surface_compensée || 
+                nids_évités || nids_compensés}
+                <p class="impacts-quantifiés">
+                    {#if surface_évitée}<span><strong>Surface évitée&nbsp;:</strong> {surface_évitée}m²</span>{/if}
+                    {#if surface_compensée}<span><strong>Surface compensée&nbsp;:</strong> {surface_compensée}m²</span>{/if}
+                    {#if individus_évités}<span><strong>Individus évités&nbsp;:</strong> {individus_évités}</span>{/if}
+                    {#if individus_compensés}<span><strong>Individus compensés&nbsp;:</strong> {individus_compensés}</span>{/if}
+                    {#if nids_évités}<span><strong>Nids évités&nbsp;:</strong> {nids_évités}</span>{/if}
+                    {#if nids_compensés}<span><strong>Nids compensés&nbsp;:</strong> {nids_compensés}</span>{/if}
+                </p>
             {/if}
 
-            {#each contrôles as contrôle}
-                {#if contrôle === contrôleEnModification}
-                    <h6>Modification du contrôle</h6>
+            {#if contrôlesOuverts}
+            <button class="contrôles fr-btn fr-btn--secondary fr-btn--icon-left fr-icon-survey-line" 
+                on:click={() => fermerContrôles()}>
+                Fermer contrôles
+            </button>
+            {:else}
+            <button class="contrôles fr-btn fr-btn--secondary fr-btn--icon-left fr-icon-survey-line" 
+                on:click={() => ouvrirContrôles()}>
+                Ouvrir contrôles
+            </button>
+            {/if}
 
-                    <FormulaireContrôle contrôle={contrôleEnModification} onValider={validerModificationsContrôle}>
-                        <button
-                            slot="bouton-annuler"
-                            type="button"
-                            class="fr-btn fr-btn--secondary"
-                            on:click={() => (contrôleEnModification = undefined)}
-                        >
-                            Annuler
-                        </button>
+            {#if contrôlesOuverts}
+                <section class="contrôles">
+                    <h6>{#if contrôles.size === 1}1 contrôle{:else}{contrôles.size} contrôles {/if}</h6>
 
-                        <div slot="bouton-supprimer" class="bouton-supprimer">
+                    <button class="fr-btn fr-btn--icon-left fr-icon-add-line" on:click={ajouterContrôle}>
+                        Ajouter un contrôle
+                    </button>
+
+                    {#if contrôleEnCours}
+                        <FormulaireContrôle contrôle={contrôleEnCours} onValider={créerContrôle}>
+                            <button slot="bouton-valider" type="submit" class="fr-btn fr-btn--icon-left fr-icon-check-line">
+                                Finir le contrôle
+                            </button>
                             <button
-                                
+                                slot="bouton-annuler"
                                 type="button"
-                                class="fr-btn fr-btn--secondary fr-icon-delete-line fr-btn--icon-left"
-                                on:click={supprimerContrôleEnModification}
+                                class="fr-btn fr-btn--secondary"
+                                on:click={() => (contrôleEnCours = undefined)}
                             >
-                                Supprimer
+                                Fermer le contrôle sans sauvegarder
                             </button>
-                        </div>
-                    </FormulaireContrôle>
-                {:else}
-                    <section class="contrôle">
-                        <h6>
-                            Contrôle du <time datetime={contrôle.date_contrôle?.toISOString()}>{formatDateAbsolue(contrôle.date_contrôle)}</time>
-                            <button class="contrôles fr-btn fr-btn--secondary fr-btn--sm fr-btn--icon-left fr-icon-pencil-line" 
-                                on:click={() => passerContrôleEnModification(contrôle)}>
-                                Modifier
-                            </button>
-                        </h6>
-                        <strong>Résultat&nbsp;:</strong> {contrôle.résultat}<br>
-                        <strong>Commentaire&nbsp;:</strong> {contrôle.commentaire}<br>
-                        <strong>Action suite au contrôle&nbsp;:</strong> {contrôle.type_action_suite_contrôle}<br>
-                        <strong>Date action suite au contrôle&nbsp;:</strong> 
-                            <time datetime={contrôle.date_action_suite_contrôle?.toISOString()}>{formatDateRelative(contrôle.date_action_suite_contrôle)}</time>
-                        <br>
-                        <strong>Date prochaine échéance&nbsp;:</strong> 
-                            <time datetime={contrôle.date_prochaine_échéance?.toISOString()}>{formatDateRelative(contrôle.date_prochaine_échéance)}</time>
-                        <br>
-                    </section>
-                {/if}
-            {/each}
+                        </FormulaireContrôle>
+                    {/if}
+
+                    {#each contrôles as contrôle}
+                        {#if contrôle === contrôleEnModification}
+                            <h6>Modification du contrôle</h6>
+
+                            <FormulaireContrôle contrôle={contrôleEnModification} onValider={validerModificationsContrôle}>
+                                <button
+                                    slot="bouton-annuler"
+                                    type="button"
+                                    class="fr-btn fr-btn--secondary"
+                                    on:click={() => (contrôleEnModification = undefined)}
+                                >
+                                    Annuler
+                                </button>
+
+                                <div slot="bouton-supprimer" class="bouton-supprimer">
+                                    <button
+                                        
+                                        type="button"
+                                        class="fr-btn fr-btn--secondary fr-icon-delete-line fr-btn--icon-left"
+                                        on:click={supprimerContrôleEnModification}
+                                    >
+                                        Supprimer
+                                    </button>
+                                </div>
+                            </FormulaireContrôle>
+                        {:else}
+                            <section class="contrôle">
+                                <h6>
+                                    Contrôle du <time datetime={contrôle.date_contrôle?.toISOString()}>{formatDateAbsolue(contrôle.date_contrôle)}</time>
+                                    <button class="contrôles fr-btn fr-btn--secondary fr-btn--sm fr-btn--icon-left fr-icon-pencil-line" 
+                                        on:click={() => passerContrôleEnModification(contrôle)}>
+                                        Modifier
+                                    </button>
+                                </h6>
+                                <strong>Résultat&nbsp;:</strong> {contrôle.résultat}<br>
+                                <strong>Commentaire&nbsp;:</strong> {contrôle.commentaire}<br>
+                                <strong>Action suite au contrôle&nbsp;:</strong> {contrôle.type_action_suite_contrôle}<br>
+                                <strong>Date action suite au contrôle&nbsp;:</strong> 
+                                    <time datetime={contrôle.date_action_suite_contrôle?.toISOString()}>{formatDateRelative(contrôle.date_action_suite_contrôle)}</time>
+                                <br>
+                                <strong>Date prochaine échéance&nbsp;:</strong> 
+                                    <time datetime={contrôle.date_prochaine_échéance?.toISOString()}>{formatDateRelative(contrôle.date_prochaine_échéance)}</time>
+                                <br>
+                            </section>
+                        {/if}
+                    {/each}
+                </section>
+
+            {/if}
         </section>
-
-    {/if}
-
+    </DéplierReplier>
+    
 </section>
 
 <style lang="scss">

--- a/scripts/front-end/components/Dossier/Contrôles/Prescription.svelte
+++ b/scripts/front-end/components/Dossier/Contrôles/Prescription.svelte
@@ -144,12 +144,12 @@
             {/if}
 
             {#if contrôlesOuverts}
-            <button class="contrôles fr-btn fr-btn--secondary fr-btn--icon-left fr-icon-survey-line" 
+            <button class="contrôles fr-btn fr-btn--secondary fr-btn--sm fr-btn--icon-left fr-icon-survey-line" 
                 on:click={() => fermerContrôles()}>
                 Fermer contrôles
             </button>
             {:else}
-            <button class="contrôles fr-btn fr-btn--secondary fr-btn--icon-left fr-icon-survey-line" 
+            <button class="contrôles fr-btn fr-btn--secondary fr-btn--sm fr-btn--icon-left fr-icon-survey-line" 
                 on:click={() => ouvrirContrôles()}>
                 Ouvrir contrôles
             </button>

--- a/scripts/front-end/components/Dossier/DossierContrôles.svelte
+++ b/scripts/front-end/components/Dossier/DossierContrôles.svelte
@@ -68,8 +68,7 @@
 </script>
 
 <div class="row">
-    <h2>Contrôles</h2>
-    <h3>Décisions administratives</h3>
+    <h2>Décisions administratives</h2>
 
     {#if décisionsAdministratives.length === 0}
         <p>Il n'y a pas de décisions administrative à contrôler concernant ce dossier</p>

--- a/scripts/front-end/components/common/DéplierReplier.svelte
+++ b/scripts/front-end/components/common/DéplierReplier.svelte
@@ -28,7 +28,7 @@ details{
             padding: 0.2em 0.4em;
             margin-left: 0.5em;
 
-            content: "Déplier ⮞";
+            content: "Déplier 🢂";
             white-space: pre;
             font-size: 0.8rem;
             color: var(--border-action-high-blue-france);
@@ -38,7 +38,7 @@ details{
 
     &[open]{
         summary::after{
-            content: "Replier ⮟";
+            content: "Replier 🢃";
         }
     }
 }

--- a/scripts/front-end/components/common/DéplierReplier.svelte
+++ b/scripts/front-end/components/common/DéplierReplier.svelte
@@ -3,8 +3,6 @@
 /** @type {boolean}*/
 export let open = false
 
-
-
 </script>
 
 <details {open}>
@@ -18,16 +16,31 @@ export let open = false
 details{
 
     summary{
+        display: flex;
+        flex-direction: row;
+        align-items: baseline;
+
         &::marker{
             content: "";
         }
 
         &::after{
+            padding: 0.2em 0.4em;
+            margin-left: 0.5em;
+
             content: "Déplier ⮞";
+            white-space: pre;
+            font-size: 0.8rem;
+            color: var(--border-action-high-blue-france);
+            border: 1px solid var(--border-action-high-blue-france);
+        }
+    }
+
+    &[open]{
+        summary::after{
+            content: "Replier ⮟";
         }
     }
 }
-
-// ⮟
 
 </style>

--- a/scripts/front-end/components/common/DéplierReplier.svelte
+++ b/scripts/front-end/components/common/DéplierReplier.svelte
@@ -1,0 +1,33 @@
+<script>
+
+/** @type {boolean}*/
+export let open = false
+
+
+
+</script>
+
+<details {open}>
+    <summary>
+        <slot name="summary"></slot>
+    </summary>
+    <slot name="content"></slot>
+</details>
+
+<style lang="scss">
+details{
+
+    summary{
+        &::marker{
+            content: "";
+        }
+
+        &::after{
+            content: "Déplier ⮞";
+        }
+    }
+}
+
+// ⮟
+
+</style>

--- a/scripts/front-end/components/common/DéplierReplier.svelte
+++ b/scripts/front-end/components/common/DéplierReplier.svelte
@@ -1,5 +1,13 @@
 <script>
 
+/**
+ * Composant utilisé pour un usage un peu similaire à l'accordéon du DSFR...
+ * https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/accordeon
+ * 
+ * ...mais quand celui-ci est trop balourd et qu'on préfère un details/summary pus léger visuellement 
+ * et standard
+ */
+
 /** @type {boolean}*/
 export let open = false
 


### PR DESCRIPTION
C'est plus facile de review sans les white-space

Pour ne pas juste créer un composant, je l'ai utilisé direct pour wrapper les prescriptions

(et j'en ai profité pour enlever le titre Contrôles :hand_over_mouth:  )