### PR TITLE
Créer tag résultat contrôle

### DIFF
--- a/scripts/front-end/components/Dossier/Contrôles/Prescription.svelte
+++ b/scripts/front-end/components/Dossier/Contrôles/Prescription.svelte
@@ -1,6 +1,7 @@
 <script>
     import FormulaireContrôle from './FormulaireContrôle.svelte'
     import DéplierReplier from '../../common/DéplierReplier.svelte'
+    import TagRésultatContrôle from '../../TagRésultatContrôle.svelte'
 
     import {formatDateRelative, formatDateAbsolue} from '../../../affichageDossier.js'
     import {ajouterContrôle as envoyerContrôle, modifierContrôle, supprimerContrôle} from '../../../actions/contrôle.js'
@@ -176,6 +177,7 @@
                             >
                                 Fermer le contrôle sans sauvegarder
                             </button>
+
                         </FormulaireContrôle>
                     {/if}
 
@@ -204,16 +206,17 @@
                                     </button>
                                 </div>
                             </FormulaireContrôle>
+
                         {:else}
                             <section class="contrôle">
                                 <h6>
                                     Contrôle du <time datetime={contrôle.date_contrôle?.toISOString()}>{formatDateAbsolue(contrôle.date_contrôle)}</time>
+                                    <TagRésultatContrôle résultatContrôle={contrôle.résultat || NON_RENSEIGNÉ}></TagRésultatContrôle>
                                     <button class="contrôles fr-btn fr-btn--secondary fr-btn--sm fr-btn--icon-left fr-icon-pencil-line" 
                                         on:click={() => passerContrôleEnModification(contrôle)}>
                                         Modifier
                                     </button>
                                 </h6>
-                                <strong>Résultat&nbsp;:</strong> {contrôle.résultat}<br>
                                 <strong>Commentaire&nbsp;:</strong> {contrôle.commentaire}<br>
                                 <strong>Action suite au contrôle&nbsp;:</strong> {contrôle.type_action_suite_contrôle}<br>
                                 <strong>Date action suite au contrôle&nbsp;:</strong> 
@@ -226,11 +229,9 @@
                         {/if}
                     {/each}
                 </section>
-
             {/if}
         </section>
     </DéplierReplier>
-    
 </section>
 
 <style lang="scss">

--- a/scripts/front-end/components/Dossier/Contrôles/Prescription.svelte
+++ b/scripts/front-end/components/Dossier/Contrôles/Prescription.svelte
@@ -117,7 +117,13 @@
 <section class="prescription-consultée">
     <DéplierReplier>
         <h6 slot="summary">
-            {description} 
+            {#if description}
+                {description}
+            {:else if numéro_article}
+                Numéro article&nbsp;:&nbsp;{numéro_article}
+            {:else}
+                (Prescription non renseignée)
+            {/if}
         </h6>
         <section slot="content">
             {#if numéro_article}

--- a/scripts/front-end/components/TagRésultatContrôle.svelte
+++ b/scripts/front-end/components/TagRésultatContrôle.svelte
@@ -7,7 +7,7 @@
     /** @import { RésultatContrôle } from '../../types/API_Pitchou.ts' */
 	
 
-    /** @type {RésultatContrôle} */
+    /** @type {RésultatContrôle | string} */
     export let résultatContrôle
 
     // https://www.systeme-de-design.gouv.fr/composants-et-modeles/composants/tag/
@@ -42,6 +42,7 @@
     $: allClasses = [
         'fr-tag',
         tailleToClass.get(taille),
+        // @ts-ignore
         résultatToClass.get(résultatContrôle),
         ...classes
     ]
@@ -71,12 +72,9 @@
 
 
 <style lang="scss">
-    $couleur-phase-accompagnement-amont: var(--artwork-minor-yellow-tournesol);
-    $couleur-phase-étude-recevabilité: var(--background-action-high-orange-terre-battue);
-    $couleur-phase-instruction: var(--background-flat-blue-cumulus);
-    $couleur-phase-contrôle: var(--background-flat-pink-tuile);
-    $couleur-phase-classé-sans-suite: var(--background-flat-green-menthe);
-    $couleur-phase-obligations-terminées: var(--background-flat-purple-glycine);
+    $couleur-résultat-contrôle-conforme: var(--background-flat-success);
+    $couleur-résultat-contrôle-non-conforme: var(--background-flat-error);
+    $couleur-résultat-contrôle-autre: var(--background-flat-beige-gris-galet);
 
     p{
         white-space: nowrap;
@@ -89,58 +87,27 @@
             background-image: none;
         }
 
-        &.phase--accompagnement-amont{
-            background-color: $couleur-phase-accompagnement-amont;
-            color: var(--text-inverted-yellow-tournesol);
+        &.résultat--conforme{
+            background-color: $couleur-résultat-contrôle-conforme;
+            color: var(--text-inverted-success);
 
             &::after{
-                color: $couleur-phase-accompagnement-amont;
+                color: $couleur-résultat-contrôle-conforme;
             }
         }
-        &.phase--étude-recevabilité{
-            background-color: $couleur-phase-étude-recevabilité;
-            color: var(--text-inverted-orange-terre-battue);
+        &.résultat--non-conforme,
+        &.résultat--non-conforme-pas-information{
+            background-color: $couleur-résultat-contrôle-non-conforme;
+            color: var(--text-inverted-error);
             
             &::after{
-                color: $couleur-phase-étude-recevabilité;
-            }
-        }
-        &.phase--instruction{
-            background-color: $couleur-phase-instruction;
-            color: var(--text-inverted-blue-cumulus);
-            
-            &::after{
-                color: $couleur-phase-instruction;
-            }
-        }
-        &.phase--contrôle{
-            background-color: $couleur-phase-contrôle;
-            color: var(--text-inverted-pink-tuile);
-            
-            &::after{
-                color: $couleur-phase-contrôle;
-            }
-        }
-        &.phase--classé-sans-suite{
-            background-color: $couleur-phase-classé-sans-suite;
-            color: var(--text-inverted-green-menthe);
-            
-            &::after{
-                color: $couleur-phase-classé-sans-suite;
-            }
-        }
-        &.phase--obligations-terminées{
-            background-color: $couleur-phase-obligations-terminées;
-            color: var(--text-inverted-purple-glycine);
-            
-            &::after{
-                color: $couleur-phase-obligations-terminées;
+                color: $couleur-résultat-contrôle-non-conforme;
             }
         }
     }
 
     button.fr-tag[aria-pressed="false"]{
-        &.phase--accompagnement-amont{
+        /*&.phase--accompagnement-amont{
             color: $couleur-phase-accompagnement-amont;
             border: 1px solid $couleur-phase-accompagnement-amont;
         }
@@ -163,6 +130,6 @@
         &.phase--obligations-terminées{
             color: $couleur-phase-obligations-terminées;
             border: 1px solid $couleur-phase-obligations-terminées;
-        }
+        }*/
     }
 </style>

--- a/scripts/front-end/components/TagRésultatContrôle.svelte
+++ b/scripts/front-end/components/TagRésultatContrôle.svelte
@@ -15,12 +15,6 @@
     /** @type {'SM' | 'MD'} */
     export let taille = 'SM'
 
-    /** @type {MouseEventHandler<HTMLButtonElement> | undefined} */
-    export let onClick = undefined
-
-    /** @type {boolean | undefined} */
-    export let ariaPressed = undefined
-
     /** @type {string[]} */
     export let classes = []
 
@@ -43,32 +37,15 @@
         'fr-tag',
         tailleToClass.get(taille),
         // @ts-ignore
-        résultatToClass.get(résultatContrôle),
+        résultatToClass.get(résultatContrôle) || 'résultat--autre',
         ...classes
     ]
 
 
-    /**
-     * Le DSFR rajoute ses propres listeners pour gérer les aria-pressed, mais on n'en a pas besoin
-     * alors, on désactive la propagation des évènements pour éviter des problèmes d'affichage
-    */
-    /** @type {MouseEventHandler<HTMLButtonElement>} */
-    function onClickWithDSFROverride(e){
-        if(onClick){
-            e.stopImmediatePropagation()
-            onClick(e)
-        }
-    }
 
 </script>
 
-{#if typeof onClick === 'function'}
-    <button class={clsx(allClasses)} aria-pressed={ariaPressed} on:click={onClickWithDSFROverride} type="button">{résultatContrôle}</button>
-{:else}
-    <p class={clsx(allClasses)}>{résultatContrôle}</p>
-{/if}
-
-
+<p class={clsx(allClasses)}>{résultatContrôle}</p>
 
 
 <style lang="scss">
@@ -77,59 +54,27 @@
     $couleur-résultat-contrôle-autre: var(--background-flat-beige-gris-galet);
 
     p{
-        white-space: nowrap;
-    }
-
-    p, button.fr-tag[aria-pressed="true"]{
-
         // DSFR override
         &, &:hover{
             background-image: none;
         }
 
+        &.résultat--en-cours,
+        &.résultat--trop-tard,
+        &.résultat--autre{
+            background-color: $couleur-résultat-contrôle-autre;
+            color: var(--text-inverted-beige-gris-galet);
+        }
+        
         &.résultat--conforme{
             background-color: $couleur-résultat-contrôle-conforme;
             color: var(--text-inverted-success);
-
-            &::after{
-                color: $couleur-résultat-contrôle-conforme;
-            }
         }
+
         &.résultat--non-conforme,
         &.résultat--non-conforme-pas-information{
             background-color: $couleur-résultat-contrôle-non-conforme;
             color: var(--text-inverted-error);
-            
-            &::after{
-                color: $couleur-résultat-contrôle-non-conforme;
-            }
         }
-    }
-
-    button.fr-tag[aria-pressed="false"]{
-        /*&.phase--accompagnement-amont{
-            color: $couleur-phase-accompagnement-amont;
-            border: 1px solid $couleur-phase-accompagnement-amont;
-        }
-        &.phase--étude-recevabilité{
-            color: $couleur-phase-étude-recevabilité;
-            border: 1px solid $couleur-phase-étude-recevabilité;
-        }
-        &.phase--instruction{
-            color: $couleur-phase-instruction;
-            border: 1px solid $couleur-phase-instruction;
-        }
-        &.phase--contrôle{
-            color: $couleur-phase-contrôle;
-            border: 1px solid $couleur-phase-contrôle;
-        }
-        &.phase--classé-sans-suite{
-            color: $couleur-phase-classé-sans-suite;
-            border: 1px solid $couleur-phase-classé-sans-suite;
-        }
-        &.phase--obligations-terminées{
-            color: $couleur-phase-obligations-terminées;
-            border: 1px solid $couleur-phase-obligations-terminées;
-        }*/
     }
 </style>

--- a/scripts/front-end/components/TagRésultatContrôle.svelte
+++ b/scripts/front-end/components/TagRésultatContrôle.svelte
@@ -1,0 +1,168 @@
+<script>
+    //@ts-check
+  
+    import clsx from 'clsx'
+
+	/** @import { MouseEventHandler } from 'svelte/elements' */
+    /** @import { RésultatContrôle } from '../../types/API_Pitchou.ts' */
+	
+
+    /** @type {RésultatContrôle} */
+    export let résultatContrôle
+
+    // https://www.systeme-de-design.gouv.fr/composants-et-modeles/composants/tag/
+
+    /** @type {'SM' | 'MD'} */
+    export let taille = 'SM'
+
+    /** @type {MouseEventHandler<HTMLButtonElement> | undefined} */
+    export let onClick = undefined
+
+    /** @type {boolean | undefined} */
+    export let ariaPressed = undefined
+
+    /** @type {string[]} */
+    export let classes = []
+
+    /** @type {Map<RésultatContrôle, string>} */
+    const résultatToClass = new Map([
+        ['Conforme', 'résultat--conforme'],
+        ['Non conforme', 'résultat--non-conforme'],
+        ['Non conforme (Pas d\'informations reçues)', 'résultat--non-conforme-pas-information'],
+        ['En cours', 'résultat--en-cours'],
+        ['Trop tard', 'résultat--trop-tard']
+    ])
+
+    /** @type {Map<typeof taille, string>} */
+    const tailleToClass = new Map([
+        ['SM', 'fr-tag--sm'],
+        ['MD', 'fr-tag--md']
+    ])
+
+    $: allClasses = [
+        'fr-tag',
+        tailleToClass.get(taille),
+        résultatToClass.get(résultatContrôle),
+        ...classes
+    ]
+
+
+    /**
+     * Le DSFR rajoute ses propres listeners pour gérer les aria-pressed, mais on n'en a pas besoin
+     * alors, on désactive la propagation des évènements pour éviter des problèmes d'affichage
+    */
+    /** @type {MouseEventHandler<HTMLButtonElement>} */
+    function onClickWithDSFROverride(e){
+        if(onClick){
+            e.stopImmediatePropagation()
+            onClick(e)
+        }
+    }
+
+</script>
+
+{#if typeof onClick === 'function'}
+    <button class={clsx(allClasses)} aria-pressed={ariaPressed} on:click={onClickWithDSFROverride} type="button">{résultatContrôle}</button>
+{:else}
+    <p class={clsx(allClasses)}>{résultatContrôle}</p>
+{/if}
+
+
+
+
+<style lang="scss">
+    $couleur-phase-accompagnement-amont: var(--artwork-minor-yellow-tournesol);
+    $couleur-phase-étude-recevabilité: var(--background-action-high-orange-terre-battue);
+    $couleur-phase-instruction: var(--background-flat-blue-cumulus);
+    $couleur-phase-contrôle: var(--background-flat-pink-tuile);
+    $couleur-phase-classé-sans-suite: var(--background-flat-green-menthe);
+    $couleur-phase-obligations-terminées: var(--background-flat-purple-glycine);
+
+    p{
+        white-space: nowrap;
+    }
+
+    p, button.fr-tag[aria-pressed="true"]{
+
+        // DSFR override
+        &, &:hover{
+            background-image: none;
+        }
+
+        &.phase--accompagnement-amont{
+            background-color: $couleur-phase-accompagnement-amont;
+            color: var(--text-inverted-yellow-tournesol);
+
+            &::after{
+                color: $couleur-phase-accompagnement-amont;
+            }
+        }
+        &.phase--étude-recevabilité{
+            background-color: $couleur-phase-étude-recevabilité;
+            color: var(--text-inverted-orange-terre-battue);
+            
+            &::after{
+                color: $couleur-phase-étude-recevabilité;
+            }
+        }
+        &.phase--instruction{
+            background-color: $couleur-phase-instruction;
+            color: var(--text-inverted-blue-cumulus);
+            
+            &::after{
+                color: $couleur-phase-instruction;
+            }
+        }
+        &.phase--contrôle{
+            background-color: $couleur-phase-contrôle;
+            color: var(--text-inverted-pink-tuile);
+            
+            &::after{
+                color: $couleur-phase-contrôle;
+            }
+        }
+        &.phase--classé-sans-suite{
+            background-color: $couleur-phase-classé-sans-suite;
+            color: var(--text-inverted-green-menthe);
+            
+            &::after{
+                color: $couleur-phase-classé-sans-suite;
+            }
+        }
+        &.phase--obligations-terminées{
+            background-color: $couleur-phase-obligations-terminées;
+            color: var(--text-inverted-purple-glycine);
+            
+            &::after{
+                color: $couleur-phase-obligations-terminées;
+            }
+        }
+    }
+
+    button.fr-tag[aria-pressed="false"]{
+        &.phase--accompagnement-amont{
+            color: $couleur-phase-accompagnement-amont;
+            border: 1px solid $couleur-phase-accompagnement-amont;
+        }
+        &.phase--étude-recevabilité{
+            color: $couleur-phase-étude-recevabilité;
+            border: 1px solid $couleur-phase-étude-recevabilité;
+        }
+        &.phase--instruction{
+            color: $couleur-phase-instruction;
+            border: 1px solid $couleur-phase-instruction;
+        }
+        &.phase--contrôle{
+            color: $couleur-phase-contrôle;
+            border: 1px solid $couleur-phase-contrôle;
+        }
+        &.phase--classé-sans-suite{
+            color: $couleur-phase-classé-sans-suite;
+            border: 1px solid $couleur-phase-classé-sans-suite;
+        }
+        &.phase--obligations-terminées{
+            color: $couleur-phase-obligations-terminées;
+            border: 1px solid $couleur-phase-obligations-terminées;
+        }
+    }
+</style>

--- a/scripts/front-end/components/TagRésultatContrôle.svelte
+++ b/scripts/front-end/components/TagRésultatContrôle.svelte
@@ -3,7 +3,6 @@
   
     import clsx from 'clsx'
 
-	/** @import { MouseEventHandler } from 'svelte/elements' */
     /** @import { RésultatContrôle } from '../../types/API_Pitchou.ts' */
 	
 

--- a/scripts/front-end/components/common/DéplierReplier.svelte
+++ b/scripts/front-end/components/common/DéplierReplier.svelte
@@ -36,7 +36,7 @@ details{
             padding: 0.2em 0.4em;
             margin-left: 0.5em;
 
-            content: "Déplier 🢂";
+            content: "Déplier →";
             white-space: pre;
             font-size: 0.8rem;
             color: var(--border-action-high-blue-france);
@@ -46,7 +46,7 @@ details{
 
     &[open]{
         summary::after{
-            content: "Replier 🢃";
+            content: "Replier ↓";
         }
     }
 }


### PR DESCRIPTION
Un composant tag pour le résultat des contrôles

Le résultat est passé dans le titre, ce qui a le bon goût que les contrôles prennent visuellement moins de place

<img width="1120" height="493" alt="Screenshot 2025-07-31 at 14-47-16 Pitchou" src="https://github.com/user-attachments/assets/49e10ff7-b7ed-44e3-b718-6af5b420a466" />
