### PR TITLE
Correctif urgent car impossible de se connecter avec un nouveau lien …

### DIFF
--- a/scripts/types/typeguards.js
+++ b/scripts/types/typeguards.js
@@ -90,10 +90,7 @@ function isDossierRésumé(x) {
   if (!phaseValid || !actionValid) return false;
 
   // DonnéesDossierPourStats
-  const statsValid = (
-      (x.historique_date_réception_ddep === null || isValidDateString(x.historique_date_réception_ddep))
-      && isValidDateString(x.date_dépôt)
-  );
+  const statsValid = isValidDateString(x.date_dépôt)
 
   return statsValid;
 };

--- a/scripts/types/typeguards.js
+++ b/scripts/types/typeguards.js
@@ -1,11 +1,12 @@
+/** @import {DossierRésumé} from '../types/API_Pitchou.ts' */
 import { isValidDateString } from '../commun/typeFormat.js'
 
 //@ts-expect-error TS ne comprends pas que le type est utilisé dans le jsdoc
 /** @import {default as Dossier} from '../scripts/types/database/public/Dossier.ts' */
 //@ts-expect-error TS ne comprends pas que le type est utilisé dans le jsdoc
 /** @import {OiseauAtteint, FauneNonOiseauAtteinte, FloreAtteinte} from '../types/especes.d.ts' */
-//@ts-expect-error TS ne comprends pas que le type est utilisé dans le jsdoc
-/** @import {DossierRésumé} from '../types/API_Pitchou.ts' */
+
+
 
 /** 
  * 


### PR DESCRIPTION
je ne peux plus me connecter en local et en prod car le typeguard `isDossierRésumé` rejetait une erreur.
Cette erreur venait du fait que l'on a oublié de supprimer la mention de `historique_date_réception_ddep` dans la dernière PR.
Cette erreur empêche de se connecter suite au clic d'un lien de connexion