### PR TITLE
Garantir que le dossier est rafraichi après qu'il ai été modifié/créé

### DIFF
--- a/scripts/front-end/actions/décisionAdministrative.js
+++ b/scripts/front-end/actions/décisionAdministrative.js
@@ -157,18 +157,18 @@ export function supprimerDécisionAdministrative(décisionAdministrativeId){
  * 
  * @param {DécisionAdministrativePourTransfer} décisionAdministrativeEnCréation 
  */
-export function sauvegardeNouvelleDécisionAdministrative(décisionAdministrativeEnCréation){
+export async function sauvegardeNouvelleDécisionAdministrative(décisionAdministrativeEnCréation){
     const modifierDécisionAdministrativeDansDossier = store.state.capabilities.modifierDécisionAdministrativeDansDossier
 
     if(!modifierDécisionAdministrativeDansDossier){
         throw new Error(`Pas les droits suffisants pour créer une décision administrative`)
     }
 
-    modifierDécisionAdministrativeDansDossier(décisionAdministrativeEnCréation) 
-
     if(!décisionAdministrativeEnCréation.dossier){
         throw new TypeError(`décisionAdministrativeEnCréation.dossier manquant dans sauvegardeNouvelleDécisionAdministrative`)
     }
+
+    await modifierDécisionAdministrativeDansDossier(décisionAdministrativeEnCréation) 
 
     refreshDossierComplet(décisionAdministrativeEnCréation.dossier)
 }

--- a/scripts/front-end/components/Dossier/DossierContrôles.svelte
+++ b/scripts/front-end/components/Dossier/DossierContrôles.svelte
@@ -25,7 +25,7 @@
     let décisionsAdministratives = $derived(dossier.décisionsAdministratives || [])
 
     //$inspect('dossier', dossier)
-    $inspect('décisionsAdministratives', décisionsAdministratives)
+    //$inspect('décisionsAdministratives', décisionsAdministratives)
 
     /**
      * 

--- a/scripts/front-end/components/Dossier/DossierContrôles.svelte
+++ b/scripts/front-end/components/Dossier/DossierContrôles.svelte
@@ -25,7 +25,7 @@
     let décisionsAdministratives = $derived(dossier.décisionsAdministratives || [])
 
     //$inspect('dossier', dossier)
-    //$inspect('décisionsAdministratives', décisionsAdministratives)
+    $inspect('décisionsAdministratives', décisionsAdministratives)
 
     /**
      * 


### PR DESCRIPTION
il n’y avait pas de garantie que `refreshDossierComplet` se termine après `modifierDécisionAdministrativeDansDossier`

Spécifiquement quand la création a un gros fichier (et donc que `modifierDécisionAdministrativeDansDossier` met du temps à terminer parce qu’il y a un gros transfert réseau)

grâce au `await`, on va s'assurer que c'est bon
le changement optimiste de l'UI fournit une UX fluide