### PR TITLE
Améliorer la structure de la page

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,9 +42,7 @@
     <script src="/build/rollup-bundle-pitchou.js" type="module" crossorigin="anonymous"></script>
 </head>
 <body>
-    <main>
-        <section class="svelte-main fr-container"></section>
-    </main>
+    <div class="svelte-main fr-container"></div>
     <!-- https://www.systeme-de-design.gouv.fr/utilisation-et-organisation/developpeurs/api-javascript -->
     <script type="module" src="/docs/style/dsfr/dsfr.module.js"></script>
 </body>

--- a/scripts/front-end/components/Squelette.svelte
+++ b/scripts/front-end/components/Squelette.svelte
@@ -155,23 +155,25 @@
     </nav>
 {/if}
 
-{#if erreurs.size >= 1}
-    <section class="erreurs fr-grid-row fr-grid-row--center">
-        <div class="fr-col">
-        {#each [...erreurs] as erreur}
-            <div class="fr-alert-background fr-mb-1w">
-                <div class="fr-alert fr-alert--error fr-alert--sm">
-                    <p><strong>Erreur&nbsp;:&nbsp;</strong>{erreur.message}</p>
-                    <button onclick={() => enleverErreur(erreur)} class="fr-link--close fr-link">Masquer le message</button>
+<main>
+    {#if erreurs.size >= 1}
+        <section class="erreurs fr-grid-row fr-grid-row--center">
+            <div class="fr-col">
+            {#each [...erreurs] as erreur}
+                <div class="fr-alert-background fr-mb-1w">
+                    <div class="fr-alert fr-alert--error fr-alert--sm">
+                        <p><strong>Erreur&nbsp;:&nbsp;</strong>{erreur.message}</p>
+                        <button onclick={() => enleverErreur(erreur)} class="fr-link--close fr-link">Masquer le message</button>
+                    </div>
                 </div>
+            {/each}
             </div>
-        {/each}
-        </div>
-    </section>
-{/if}
+        </section>
+    {/if}
 
 
-{@render children?.()}
+    {@render children?.()}
+</main>
 
 <footer class="fr-footer" id="footer">
     <div class="fr-container">

--- a/scripts/front-end/components/SqueletteContenuVide.svelte
+++ b/scripts/front-end/components/SqueletteContenuVide.svelte
@@ -1,7 +1,3 @@
-<svelte:head>
-    <title>Pitchou</title>
-</svelte:head>
-
 <script>
     import Squelette from './Squelette.svelte'
     import Loader from './Loader.svelte'


### PR DESCRIPTION
* sort le footer et header du main (fix l'absence des landmarks banner et contentinfo)
* sort la navigation du main pour y laisser seulement le contenu principal de la page
* supprime la définition redondante du title dans le SqueletteContenuVide