### PR TITLE
Améliorer l'accessibilité du formulaire de préremplissage de dérogation

### DIFF
--- a/scripts/front-end/components/screens/PreremplissageDerogation.svelte
+++ b/scripts/front-end/components/screens/PreremplissageDerogation.svelte
@@ -8,7 +8,7 @@
 
     /**
      * @param {string} label
-     * @returns string
+     * @returns {string}
      */
      function labelToId(label) {
         return label.replace(/[^a-zA-Z0-9]+/g, '-')
@@ -66,6 +66,30 @@
         }
     })
 
+    /** @type {(typeof groupe)[]} */
+    let champsRemplissablesGroupés = []
+
+    let groupe = {
+        /** @type {string} */
+        nom: 'Questions préliminaires',
+        /** @type {Dossier88444ChampDescriptor[]} */
+        champs: []
+    }
+
+    for (const champ of champsRemplissables) {
+        if (champ['__typename'] === 'HeaderSectionChampDescriptor') {
+            if (groupe.champs.length) {
+                champsRemplissablesGroupés.push(groupe)
+            }
+            groupe = {
+                nom: champ["label"],
+                champs: []
+            }
+        } else {
+            groupe.champs.push(champ)
+        }
+    }
+
 </script>
 
 <Squelette {email} title="Pré-remplissage dérogation">
@@ -74,33 +98,38 @@
             <h1>Pré-remplissage dérogation espèces protégées</h1>
 
             <form onchange={onSelectChanged}>
-                {#each champsRemplissables as champ}
-                    {#if champ["__typename"] == "HeaderSectionChampDescriptor"}
-                        <h3>{champ["label"]}</h3>
-                    {:else}
-                        <div class="fr-select-group">
-                            <label class="fr-label" for="{labelToId(champ["label"])}">
-                                {champ["label"]}
-                            </label>
+                {#each champsRemplissablesGroupés as groupe}
+                    <fieldset class="fr-fieldset">
+                        <legend class="fr-fieldset__legend--regular fr-fieldset__legend">
+                            <h2>{groupe.nom}</h2>
+                        </legend>
+                        {#each groupe.champs as champ }
+                            <div class="fr-fieldset__element">
+                                <div class="fr-select-group">
+                                    <label class="fr-label" for="{labelToId(champ["label"])}">
+                                        {champ["label"]}
+                                    </label>
 
-                            <select
-                                bind:value={nouveauDossierPartiel[champ["label"]]}
-                                id="{labelToId(champ["label"])}"
-                                class="fr-select"
-                            >
+                                    <select
+                                        bind:value={nouveauDossierPartiel[champ["label"]]}
+                                        id="{labelToId(champ["label"])}"
+                                        class="fr-select"
+                                    >
 
-                                <option value="" selected></option>
-                                {#if champ["options"]}
-                                    {#each champ["options"] as option}
-                                        <option value={option}>{option}</option>
-                                    {/each}
-                                {:else}
-                                    <option value={true}>Oui</option>
-                                    <option value={false}>Non</option>
-                                {/if}
-                            </select>
-                        </div>
-                    {/if}
+                                        <option value="" selected></option>
+                                        {#if champ["options"]}
+                                            {#each champ["options"] as option}
+                                                <option value={option}>{option}</option>
+                                            {/each}
+                                        {:else}
+                                            <option value={true}>Oui</option>
+                                            <option value={false}>Non</option>
+                                        {/if}
+                                    </select>
+                                </div>
+                            </div>
+                        {/each}
+                    </fieldset>
                 {/each}
             </form>
 

--- a/scripts/front-end/components/screens/PreremplissageDerogation.svelte
+++ b/scripts/front-end/components/screens/PreremplissageDerogation.svelte
@@ -6,7 +6,13 @@
     /** @import {DossierDemarcheSimplifiee88444} from "../../../types/démarches-simplifiées/DémarcheSimplifiée88444.js" */
     /** @import {SchemaDémarcheSimplifiée, Dossier88444ChampDescriptor} from '../../../types/démarches-simplifiées/schema.js' */
 
-
+    /**
+     * @param {string} label
+     * @returns string
+     */
+     function labelToId(label) {
+        return label.replace(/[^a-zA-Z0-9]+/g, '-')
+    }
 
     /**
      * @typedef {Object} Props
@@ -40,8 +46,6 @@
         "HeaderSectionChampDescriptor",
     ]
 
-
-
     /** @type {Dossier88444ChampDescriptor[]} */
     //@ts-expect-error svelte ne peut pas comprendre que les labels du schema sont les clefs de DossierDemarcheSimplifiee88444
     let champsRemplissables = schemaDS88444["revision"]["champDescriptors"].filter((champ) => {
@@ -74,32 +78,28 @@
                     {#if champ["__typename"] == "HeaderSectionChampDescriptor"}
                         <h3>{champ["label"]}</h3>
                     {:else}
-                        <fieldset class="fr-fieldset fr-p-1-5v">
-                            <div class="fr-fieldset__element">
-                                <div class="fr-input-group">
-                                    <label class="fr-label" for="{champ["label"]}">
-                                        {champ["label"]}
-                                    </label>
+                        <div class="fr-select-group">
+                            <label class="fr-label" for="{labelToId(champ["label"])}">
+                                {champ["label"]}
+                            </label>
 
-                                    <select
-                                        bind:value={nouveauDossierPartiel[champ["label"]]}
-                                        id="{champ["label"]}"
-                                        class="fr-select"
-                                    >
+                            <select
+                                bind:value={nouveauDossierPartiel[champ["label"]]}
+                                id="{labelToId(champ["label"])}"
+                                class="fr-select"
+                            >
 
-                                        <option value="" selected></option>
-                                        {#if champ["options"]}
-                                            {#each champ["options"] as option}
-                                                <option value={option}>{option}</option>
-                                            {/each}
-                                        {:else}
-                                            <option value={true}>Oui</option>
-                                            <option value={false}>Non</option>
-                                        {/if}
-                                    </select>
-                                </div>
-                            </div>
-                        </fieldset>
+                                <option value="" selected></option>
+                                {#if champ["options"]}
+                                    {#each champ["options"] as option}
+                                        <option value={option}>{option}</option>
+                                    {/each}
+                                {:else}
+                                    <option value={true}>Oui</option>
+                                    <option value={false}>Non</option>
+                                {/if}
+                            </select>
+                        </div>
                     {/if}
                 {/each}
             </form>


### PR DESCRIPTION
* Lie correctement les champs à leurs étiquettes
* Supprime les fieldsets qui n'ont qu'un champ (et pas de légende)