### PR TITLE
Ajouter le fichier html de la déclaration d'accessibilité et le lier à la mention Accessibilité : non conforme dans le pied de page

### DIFF
--- a/declaration-accessibilite_2025-07-07.html
+++ b/declaration-accessibilite_2025-07-07.html
@@ -1,4 +1,3 @@
-<!DOCTYPE html>
 <h1>Déclaration d’accessibilité</h1>
 <p>
 	Établie le

--- a/declaration-accessibilite_2025-07-07.html
+++ b/declaration-accessibilite_2025-07-07.html
@@ -1,0 +1,109 @@
+<!DOCTYPE html>
+<h1>Déclaration d’accessibilité</h1>
+<p>
+	Établie le
+	<span>7 août 2025</span>.
+</p>
+<p>
+	<span>Ministère de la Transition écologique, de la Biodiversité, de la Forêt, de la Mer et de la Pêche</span>
+	s’engage à rendre son service accessible, conformément à
+	l’article 47 de la loi n° 2005-102 du 11 février 2005.
+</p>
+<p>
+	Cette déclaration d’accessibilité s’applique à
+	<strong>Pitchou</strong><span>
+	(<span>https://pitchou.beta.gouv.fr/</span>)</span>.
+</p>
+<h2>État de conformité</h2>
+<p>
+	<strong>Pitchou</strong>
+	est
+	<strong><span data-printfilter="lowercase">non conforme</span></strong>
+	avec le
+	<abbr title="Référentiel général d’amélioration de l’accessibilité">RGAA</abbr>. <span>Le site n’a encore pas été audité.<br></span>
+</p>
+<h2>Contenus non accessibles</h2>
+<p>
+	Les contenus listés ci-dessous ne sont pas accessibles pour les
+	raisons suivantes.
+</p>
+<h3>Non conformité</h3>
+<p>
+	Malgré nos efforts, certains contenus sont inaccessibles. Vous
+	trouverez ci-dessous une liste des limitations connues et des
+	solutions potentielles&nbsp;:
+</p>
+<ol class="technical-information accessibility-limitations">
+	<li><strong>Fichiers pdf des dossiers demande de dérogation espèces protégées</strong>: Les fichiers pdf ajoutés par les utilisateurices ne sont pas forcément accessibles parce que Nous ne pouvons garantir la qualité des contributions.. Rien pour le moment. Si on nous remonte qu'un contenu n'est pas accessible, on peut contacter la personne ayant déposé le pdf pour qu'elle le rende plus accessible.</li>
+	<li><strong>Utilisation de Démarches simplifiées pour le formulaire de dépôt de dossier</strong>: Les dossiers de Pitchou sont saisis dans Démarches Simplifiées et donc l'usage de Pitchou dépend de Démarches Simplifiées et de son accessibilité parce que Parce qu'on a choisi de dépendre de DS pour le dépôt des dossiers. Remonter à l'équipe DS les soucis d'accessibilité qu'on nous remonte. Envoyer son dossier par email aux intructeurices qui saisiront le dossier à leur place en tant que mandataire.</li>
+</ol>
+<h3>Dérogations pour charge disproportionnée</h3>
+<p>L'équipe Pitchou ne pourra pas rendre l'ensemble des fichiers pdf (parfois 80p., 300p., beaucoup d'images, ...) des dossiers accessibles</p>
+<h2>Établissement de cette déclaration d’accessibilité</h2>
+<p>
+	Cette déclaration a été établie le
+	<span>7 août 2025</span>.
+</p>
+<h3>Technologies utilisées</h3>
+<p>
+	L’accessibilité de
+	<span>Pitchou</span>
+	s’appuie sur les technologies suivantes&nbsp;:
+</p>
+<ul class="technical-information technologies-used">
+	<li>HTML</li>
+	<li>WAI-ARIA</li>
+	<li>CSS</li>
+	<li>JavaScript</li>
+</ul>
+<h2>Amélioration et contact</h2>
+<p>
+	Si vous n’arrivez pas à accéder à un contenu ou à un service,
+	vous pouvez contacter le responsable de
+	<span>Pitchou</span>
+	pour être orienté vers une alternative accessible ou obtenir le
+	contenu sous une autre forme.
+</p>
+<ul class="basic-information feedback h-card">
+	<li>
+	E-mail&nbsp;:
+	<a href="mailto:pitchou@beta.gouv.fr">pitchou@beta.gouv.fr</a>
+</li>
+
+</ul>
+<p>
+	Nous essayons de répondre dans les
+	<span>1 semaine</span>.
+</p>
+<h2>Voie de recours</h2>
+<p>
+	Cette procédure est à utiliser dans le cas suivant&nbsp;: vous avez
+	signalé au responsable du site internet un défaut
+	d’accessibilité qui vous empêche d’accéder à un contenu ou à un
+	des services du portail et vous n’avez pas obtenu de réponse
+	satisfaisante.
+</p>
+<p>Vous pouvez&nbsp;:</p>
+<ul>
+	<li>
+	Écrire un message au
+	<a href="https://formulaire.defenseurdesdroits.fr/">Défenseur des droits</a>
+</li>
+	<li>
+	Contacter
+	<a href="https://www.defenseurdesdroits.fr/saisir/delegues">le délégué du Défenseur des droits dans votre région</a>
+</li>
+	<li>
+	Envoyer un courrier par la poste (gratuit, ne pas mettre de
+	timbre)&nbsp;:<br>
+	Défenseur des droits<br>
+	Libre réponse 71120 75342 Paris CEDEX 07
+</li>
+</ul>
+<hr>
+<p>
+	Cette déclaration d’accessibilité a été créé le
+	<span>7 août 2025</span>
+	grâce au
+	<a href="https://betagouv.github.io/a11y-generateur-declaration/#create">Générateur de Déclaration d’Accessibilité</a>.
+</p>

--- a/docs/_includes/footer.html
+++ b/docs/_includes/footer.html
@@ -68,9 +68,9 @@
                   <a class="fr-footer__bottom-link" href="https://github.com/betagouv/pitchou">Code source</a>
               </li>
               <li class="fr-footer__bottom-item">
-                  <span class="fr-footer__bottom-link">
-                      Accessibilité : non conforme
-                  </span>
+                     <a id="footer__bottom-link-accessibilite" href="/accessibilite" class="fr-footer__bottom-link">
+                        Accessibilité : non conforme
+                    </a>
               </li>
               <!--<li class="fr-footer__bottom-item">
                   <a class="fr-footer__bottom-link" href="#"

--- a/scripts/front-end/components/Squelette.svelte
+++ b/scripts/front-end/components/Squelette.svelte
@@ -245,9 +245,9 @@
                     <a class="fr-footer__bottom-link" href="https://github.com/betagouv/pitchou">Code source</a>
                 </li>
                 <li class="fr-footer__bottom-item">
-                    <span class="fr-footer__bottom-link">
+                     <a id="footer__bottom-link-accessibilite" href="/accessibilite" class="fr-footer__bottom-link">
                         Accessibilité : non conforme
-                    </span>
+                    </a>
                 </li>
                 <!--<li class="fr-footer__bottom-item">
                     <a class="fr-footer__bottom-link" href="#"

--- a/scripts/front-end/components/screens/Accessibilite.svelte
+++ b/scripts/front-end/components/screens/Accessibilite.svelte
@@ -1,0 +1,22 @@
+<script>
+    //@ts-check
+    import Squelette from '../Squelette.svelte'
+    import Loader from '../Loader.svelte'
+
+    /** @type {{ title?: string, html?: string }} */
+    let { title = 'Accessibilité', html = '' } = $props();
+</script>
+
+<Squelette nav={false} {title}>
+    <div class="fr-container fr-my-6w">
+        {#if html === ''}
+            <Loader></Loader>
+        {:else}
+            <div class="fr-content" aria-labelledby="titre-declaration" >
+                {@html html}
+            </div>
+        {/if}
+    </div>
+</Squelette>
+
+

--- a/scripts/front-end/main.js
+++ b/scripts/front-end/main.js
@@ -9,6 +9,7 @@ import SaisieEspèces from './routes/SaisieEspèces.js';
 import PreremplissageDerogation from './routes/PreremplissageDerogation.js';
 import TmpStats from './routes/TmpStats.js';
 import ImportDossierBFC from './routes/importDossierBFC.js';
+import Accessibilite from './routes/Accessibilite.js';
 
 import { init } from './actions/main.js';
 import Stats from './routes/Stats.js';
@@ -23,6 +24,7 @@ page('/preremplissage-derogation', PreremplissageDerogation)
 page('/tmp/stats', TmpStats)
 page('/stats', Stats)
 page('/import-dossier-historique/bourgogne-franche-comte', ImportDossierBFC)
+page('/accessibilite', Accessibilite)
 
 
 init()

--- a/scripts/front-end/routes/Accessibilite.js
+++ b/scripts/front-end/routes/Accessibilite.js
@@ -1,0 +1,33 @@
+//@ts-check
+
+/** @import {ComponentProps} from 'svelte' */
+
+import { replaceComponent } from '../routeComponentLifeCycle.svelte.js'
+import Accessibilite from '../components/screens/Accessibilite.svelte';
+
+export default async () => {
+    let html = ''
+    try {
+        const res = await fetch('/declaration-accessibilite_2025-07-07.html', { credentials: 'same-origin' })
+        html = await res.text()
+    }
+    catch (err) {
+        console.error('Erreur chargement déclaration accessibilité', err)
+        html = ''
+    }
+
+    /**
+     * 
+     * @returns {ComponentProps<typeof Accessibilite>}
+     */
+    function mapStateToProps() {
+        return {
+            title: 'Accessibilité',
+            html
+        };
+    }
+
+    replaceComponent(Accessibilite, mapStateToProps)
+}
+
+

--- a/scripts/server/main.js
+++ b/scripts/server/main.js
@@ -122,6 +122,11 @@ fastify.get('/tmp/stats', sendIndexHTMLFile)
 fastify.get('/stats', sendIndexHTMLFile)
 fastify.get('/import-dossier-historique/bourgogne-franche-comte', sendIndexHTMLFile)
 
+// Page accessibilité statique
+fastify.get('/accessibilite', function(_request, reply){
+  reply.sendFile('declaration-accessibilite_2025-07-07.html')
+})
+
 
 
 fastify.post('/lien-preremplissage', async function (request) {

--- a/scripts/server/main.js
+++ b/scripts/server/main.js
@@ -121,11 +121,7 @@ fastify.get('/preremplissage-derogation', sendIndexHTMLFile)
 fastify.get('/tmp/stats', sendIndexHTMLFile)
 fastify.get('/stats', sendIndexHTMLFile)
 fastify.get('/import-dossier-historique/bourgogne-franche-comte', sendIndexHTMLFile)
-
-// Page accessibilité statique
-fastify.get('/accessibilite', function(_request, reply){
-  reply.sendFile('declaration-accessibilite_2025-07-07.html')
-})
+fastify.get('/accessibilite', sendIndexHTMLFile)
 
 
 


### PR DESCRIPTION
J'ai rajouté le document html tel quel, en pièce-jointe dans la carte : https://trello.com/c/UEMpItpU/783-ajouter-la-d%C3%A9claration-daccessibilit%C3%A9-%C3%A0-notre-site

J'ai volontairement rien modifié même si ce n'est pas très beau

J'ai hésité à le convertir en markdown pour le servir avec Github Pages mais comme on ne risque pas de le modifer très souvent je ne l'ai pas fait