### PR TITLE
La modification des prescriptions avec contrôles ne fonctionne pas

### DIFF
--- a/scripts/front-end/actions/prescriptions.js
+++ b/scripts/front-end/actions/prescriptions.js
@@ -12,7 +12,8 @@ const inutile = true;
  * @returns {Promise<Prescription['id']>}
  */
 export function ajouterPrescription(prescription){
-    //@ts-ignore
+        //@ts-ignore
+
     return json('/prescription', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -34,14 +35,15 @@ export function ajouterPrescriptionsEtContrôles(prescription){
 
 /**
  * 
- * @param {Partial<Prescription>} prescription 
+ * @param {Partial<FrontEndPrescription>} prescription 
  * @returns {Promise<undefined>}
  */
 export function modifierPrescription(prescription){
+    const { contrôles, ...prescriptionSansContrôles } = prescription || {};
     return json('/prescription', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(prescription)
+        body: JSON.stringify(prescriptionSansContrôles)
     })
 }
 

--- a/scripts/front-end/actions/prescriptions.js
+++ b/scripts/front-end/actions/prescriptions.js
@@ -35,15 +35,14 @@ export function ajouterPrescriptionsEtContrôles(prescription){
 
 /**
  * 
- * @param {Partial<FrontEndPrescription>} prescription 
+ * @param {Partial<Prescription>} prescription 
  * @returns {Promise<undefined>}
  */
 export function modifierPrescription(prescription){
-    const { contrôles, ...prescriptionSansContrôles } = prescription || {};
     return json('/prescription', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(prescriptionSansContrôles)
+        body: JSON.stringify(prescription)
     })
 }
 

--- a/scripts/front-end/components/Dossier/Contrôles/DécisionsAdministratives.svelte
+++ b/scripts/front-end/components/Dossier/Contrôles/DécisionsAdministratives.svelte
@@ -231,7 +231,7 @@
 
             {#if vuePrescription === 'consulter'}
                 {#each prescriptions as prescription}
-                    <Prescription {prescription}></Prescription>
+                    <Prescription {prescription} refreshDossierComplet={() => refreshDossierComplet(dossierId)}></Prescription>
                 {/each}
 
                 <button class="fr-btn fr-btn--secondary fr-btn--icon-left fr-icon-ball-pen-line" onclick={() => vuePrescription = 'modifier'}>

--- a/scripts/front-end/components/Dossier/Contrôles/DécisionsAdministratives.svelte
+++ b/scripts/front-end/components/Dossier/Contrôles/DécisionsAdministratives.svelte
@@ -68,7 +68,7 @@
 
     /**
      * 
-     * @param {Partial<PrescriptionType>} prescription
+     * @param {Partial<FrontEndPrescription>} prescription
      */
     async function savePrescription(prescription){
         if(prescription.date_échéance){
@@ -76,7 +76,10 @@
         }
 
         if (prescription.id) {
-            modifierPrescription(prescription)
+            // "contrôles" est une proprété du type FrontEndPrescription pas une propriété du type Prescription
+            // ce qui pose un problème lors de l'insertion/l'update de la prescription en base de données
+            const { contrôles, ...prescriptionSansContrôles } = prescription;
+            modifierPrescription(prescriptionSansContrôles)
         } else {
             const pendingPrescriptionIdEntry = prescriptionToPendingIdAndLatestData.get(prescription)
             if(pendingPrescriptionIdEntry){

--- a/scripts/front-end/components/Dossier/Contrôles/Prescription.svelte
+++ b/scripts/front-end/components/Dossier/Contrôles/Prescription.svelte
@@ -116,11 +116,7 @@
         if(!contrôleEnModification)
             throw new TypeError(`pas de contrôle en modificaion`)
 
-        // @ts-ignore
-        const index = prescription.contrôles?.indexOf(contrôleEnModification) || -1;
-        if (index !== -1) { 
-            prescription.contrôles?.splice(index, 1); 
-        }
+        contrôles.delete(contrôleEnModification)
 
         const id = contrôleEnModification.id
         contrôleEnModification = undefined

--- a/scripts/front-end/components/Dossier/Contrôles/Prescription.svelte
+++ b/scripts/front-end/components/Dossier/Contrôles/Prescription.svelte
@@ -14,10 +14,13 @@
     /**
      * @typedef {Object} Props
      * @property {Partial<FrontEndPrescription>} prescription
+     * @property {() => Promise<any>} refreshDossierComplet
      */
 
     /** @type {Props} */
-    let { prescription } = $props();
+    let { prescription,
+        refreshDossierComplet
+     } = $props();
 
     let {
         id, description, date_échéance, numéro_article,
@@ -124,8 +127,10 @@
         if(!id){
             throw new TypeError(`il manque un id au contrôle en modificaion`)
         }
-        
+
         await supprimerContrôle(id)
+
+        refreshDossierComplet()
     }
 
 </script>


### PR DESCRIPTION
Cette PR est liée à la carte https://trello.com/c/FDzjKDPZ/849-bug-des-prescriptions-remont%C3%A9-par-vanessa-le-26-09 

voici l'erreur rencontrée : 

```
Erreur lors de l’ajout/modification de prescription. error: update “prescription” set “id” = $1, “décision_administrative” = $2, “numéro_article” = $3, “description” = $4, “surface_évitée” = $5, “surface_compensée” = $6, “nids_évités” = $7, “nids_compensés” = $8, “individus_évités” = $9, “individus_compensés” = $10, “contrôles” = $11 where “id” = $12 - column “contrôles” of relation “prescription” does not exist
```