### PR TITLE
Intégrer complètement la modale d'import d'un fichier espèces .ods dans la page saisie des espèces

### DIFF
--- a/scripts/commun/outils-espèces.js
+++ b/scripts/commun/outils-espèces.js
@@ -335,7 +335,7 @@ async function importDescriptionMenacesEspècesFromOdsArrayBuffer_version_1(odsF
         !(lignesFauneNonOiseauOds && lignesFauneNonOiseauOds.length >= 1) &&
         !(lignesFloreOds && lignesFloreOds.length >= 1)
     ) {
-        console.warn('Le fichier espèces .ods semble ne contenir aucune feuille oiseau, faune non-oiseau ou flore.')
+        throw new Error('Le fichier espèces .ods semble ne contenir aucune feuille oiseau, faune non-oiseau ou flore.')
     }
 
     if(lignesOiseauOds && lignesOiseauOds.length >= 1){

--- a/scripts/commun/outils-espèces.js
+++ b/scripts/commun/outils-espèces.js
@@ -324,7 +324,19 @@ async function importDescriptionMenacesEspècesFromOdsArrayBuffer_version_1(odsF
     const odsContent = tableRawContentToObjects(odsRawContent)
 
     let lignesOiseauOds = odsContent.get('oiseau')
+    let lignesFauneNonOiseauOds = odsContent.get('faune non-oiseau') || odsContent.get('faune_non-oiseau')
+    let lignesFloreOds = odsContent.get('flore')
+
     lignesOiseauOds = lignesOiseauOds && lignesOiseauOds.filter(ligneEspèceImpactéeHasCD_REF)
+    lignesFauneNonOiseauOds = lignesFauneNonOiseauOds && lignesFauneNonOiseauOds.filter(ligneEspèceImpactéeHasCD_REF)
+    lignesFloreOds = lignesFloreOds && lignesFloreOds.filter(ligneEspèceImpactéeHasCD_REF)
+
+    if (!(lignesOiseauOds && lignesOiseauOds.length >= 1) &&
+        !(lignesFauneNonOiseauOds && lignesFauneNonOiseauOds.length >= 1) &&
+        !(lignesFloreOds && lignesFloreOds.length >= 1)
+    ) {
+        console.warn('Le fichier espèces .ods semble ne contenir aucune feuille oiseau, faune non-oiseau ou flore.')
+    }
 
     if(lignesOiseauOds && lignesOiseauOds.length >= 1){
         // recups les infos depuis les colonnes
@@ -378,9 +390,6 @@ async function importDescriptionMenacesEspècesFromOdsArrayBuffer_version_1(odsF
         })
     }
 
-    let lignesFauneNonOiseauOds = odsContent.get('faune non-oiseau') || odsContent.get('faune_non-oiseau')
-    lignesFauneNonOiseauOds = lignesFauneNonOiseauOds && lignesFauneNonOiseauOds.filter(ligneEspèceImpactéeHasCD_REF)
-
     if(lignesFauneNonOiseauOds && lignesFauneNonOiseauOds.length >= 1){
         // recups les infos depuis les colonnes
         descriptionMenacesEspèces['faune non-oiseau'] = lignesFauneNonOiseauOds.map(ligneFauneNonOiseauOds => {
@@ -419,9 +428,6 @@ async function importDescriptionMenacesEspècesFromOdsArrayBuffer_version_1(odsF
             }
         })
     }
-
-    let lignesFloreOds = odsContent.get('flore')
-    lignesFloreOds = lignesFloreOds && lignesFloreOds.filter(ligneEspèceImpactéeHasCD_REF)
 
     if(lignesFloreOds && lignesFloreOds.length >= 1){
         // recups les infos depuis les colonnes

--- a/scripts/commun/outils-espèces.js
+++ b/scripts/commun/outils-espèces.js
@@ -335,7 +335,9 @@ async function importDescriptionMenacesEspècesFromOdsArrayBuffer_version_1(odsF
         !(lignesFauneNonOiseauOds && lignesFauneNonOiseauOds.length >= 1) &&
         !(lignesFloreOds && lignesFloreOds.length >= 1)
     ) {
-        throw new Error('Le fichier espèces .ods semble ne contenir aucune feuille oiseau, faune non-oiseau ou flore.')
+        throw new Error('Le fichier espèces .ods semble ne contenir aucune feuille oiseau, faune non-oiseau ou flore.',
+            {cause: 'format incorrect'}
+        )
     }
 
     if(lignesOiseauOds && lignesOiseauOds.length >= 1){

--- a/scripts/front-end/components/screens/SaisieEspèces.svelte
+++ b/scripts/front-end/components/screens/SaisieEspèces.svelte
@@ -120,7 +120,7 @@
             messageErreurPréRemplirAvecDocumentOds = "Une erreur est survenue au moment de cliquer sur le bouton Pré-remplir.";
             if (erreur instanceof Error) {
                 if (erreur.cause === 'format incorrect') {
-                    messageErreurPréRemplirAvecDocumentOds = 'Le fichier ne respecte pas le document .ods qui respecte le format décrit <a href="https://betagouv.github.io/pitchou/projet-pitchou/technique/fichier-especes-ods" target="_blank" rel="noopener external" title="Lien vers la page qui renseigne sur le format d\'un fichier espèces - nouvelle fenêtre">sur cette page.</a>'
+                    messageErreurPréRemplirAvecDocumentOds = `Le fichier ne respecte pas le format décrit dans <a href="https://betagouv.github.io/pitchou/projet-pitchou/technique/fichier-especes-ods" target="_blank" rel="noopener external" title="Lien vers la page qui renseigne sur le format d\'un fichier espèces - nouvelle fenêtre">la documentation des fichiers d'espèces.</a>`
                 } else {
                     messageErreurPréRemplirAvecDocumentOds = erreur.message;
                 }
@@ -334,7 +334,7 @@
                                                         un document déjà généré avec cet outil
                                                     </li>
                                                     <li>
-                                                        un document .ods qui respecte le format décrit <a href="https://betagouv.github.io/pitchou/projet-pitchou/technique/fichier-especes-ods" target="_blank" rel="noopener external" title="Lien vers la page qui renseigne sur le format d'un fichier espèces - nouvelle fenêtre" class="fr-link fr-text--sm">sur cette page</a>
+                                                        un document .ods qui respecte le format décrit dans <a href="https://betagouv.github.io/pitchou/projet-pitchou/technique/fichier-especes-ods" target="_blank" rel="noopener external" title="Lien vers la page qui renseigne sur le format d'un fichier espèces - nouvelle fenêtre" class="fr-link fr-text--sm">la documentation des fichiers d'espèces</a>
                                                     </li>
                                                 </ul>
                                             </span>

--- a/scripts/front-end/components/screens/SaisieEspèces.svelte
+++ b/scripts/front-end/components/screens/SaisieEspèces.svelte
@@ -318,7 +318,7 @@
                                                         un document déjà généré avec cet outil
                                                     </li>
                                                     <li>
-                                                        un document .ods qui respecte la nomenclature décrite <a href="https://betagouv.github.io/pitchou/projet-pitchou/technique/fichier-especes-ods" target="_blank" rel="noopener external" title="Lien vers la page de nomenclature - nouvelle fenêtre" class="fr-link">sur cette page</a>
+                                                        un document .ods qui respecte le format décrite <a href="https://betagouv.github.io/pitchou/projet-pitchou/technique/fichier-especes-ods" target="_blank" rel="noopener external" title="Lien vers la page de nomenclature - nouvelle fenêtre" class="fr-link">sur cette page</a>
                                                     </li>
                                                 </ul>
                                             </span>

--- a/scripts/front-end/components/screens/SaisieEspèces.svelte
+++ b/scripts/front-end/components/screens/SaisieEspèces.svelte
@@ -93,6 +93,7 @@
      * @param {Event & {currentTarget: HTMLElement & HTMLInputElement}} e
      */
     async function onFileInput(e){
+        messageErreurPréRemplirAvecDocumentOds = undefined
         /** @type {FileList | null} */
         const files = e.currentTarget.files
         fichierEspècesOds = files && files[0] || undefined
@@ -100,8 +101,6 @@
 
     async function onClickPréRemplirAvecDocumentOds(){
         try {
-            // Comme le fichier est bien téléchargé avec le bon format quand on arrive ici, on s'assure que la variable contenant le message d'erreur est undefined.
-            messageErreurPréRemplirAvecDocumentOds = undefined
             if(!fichierEspècesOds){
                 throw new Error("Aucun fichier espèces .ods n'a été téléchargé.")
             }

--- a/scripts/front-end/components/screens/SaisieEspèces.svelte
+++ b/scripts/front-end/components/screens/SaisieEspèces.svelte
@@ -57,6 +57,9 @@
     /** @type {HTMLInputElement | undefined} */
     let inputFileUpload = $state()
 
+    /** @type {HTMLElement | undefined} */
+    let modale;
+
     function rerender(){
         oiseauxAtteints = oiseauxAtteints
         faunesNonOiseauxAtteintes = faunesNonOiseauxAtteintes
@@ -112,7 +115,6 @@
                 faunesNonOiseauxAtteintes = descriptionMenacesEspèces['faune non-oiseau'] || []
                 floresAtteintes = descriptionMenacesEspèces['flore'] || []
 
-                const modale = document.querySelector('#modale-préremplir-depuis-import');
                 if (modale) {
                     //@ts-ignore
                     window.dsfr(modale).modal.conceal();
@@ -320,7 +322,7 @@
         </header>
         <div class="fr-grid-row">
             <div class="fr-col">
-                <dialog id="modale-préremplir-depuis-import" class="fr-modal" aria-labelledby="Pré-remplir avec une liste déjà réalisée" aria-modal="true">
+                <dialog bind:this={modale} id="modale-préremplir-depuis-import" class="fr-modal" aria-labelledby="Pré-remplir avec une liste déjà réalisée" aria-modal="true">
                     <div class="fr-container fr-container--fluid fr-container-md">
                         <div class="fr-grid-row fr-grid-row--center">
                             <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">

--- a/scripts/front-end/components/screens/SaisieEspèces.svelte
+++ b/scripts/front-end/components/screens/SaisieEspèces.svelte
@@ -318,11 +318,11 @@
                                                         un document déjà généré avec cet outil
                                                     </li>
                                                     <li>
-                                                        un document .ods qui respecte le format décrite <a href="https://betagouv.github.io/pitchou/projet-pitchou/technique/fichier-especes-ods" target="_blank" rel="noopener external" title="Lien vers la page de nomenclature - nouvelle fenêtre" class="fr-link">sur cette page</a>
+                                                        un document .ods qui respecte le format décrit <a href="https://betagouv.github.io/pitchou/projet-pitchou/technique/fichier-especes-ods" target="_blank" rel="noopener external" title="Lien vers la page qui renseigne sur le format d'un fichier espèces - nouvelle fenêtre" class="fr-link fr-text--sm">sur cette page</a>
                                                     </li>
                                                 </ul>
                                             </span>
-											<div class="fr-upload-group">
+											<div class="fr-upload-group fr-mt-6w">
 												<label class="fr-label" for="file-upload">
 													<span class="fr-hint-text">Taille maximale : 100 Mo. Formats supportés : ods</span>
 												</label>

--- a/scripts/front-end/components/screens/SaisieEspèces.svelte
+++ b/scripts/front-end/components/screens/SaisieEspèces.svelte
@@ -120,7 +120,7 @@
             messageErreurPréRemplirAvecDocumentOds = "Une erreur est survenue au moment de cliquer sur le bouton Pré-remplir.";
             if (erreur instanceof Error) {
                 if (erreur.cause === 'format incorrect') {
-                    messageErreurPréRemplirAvecDocumentOds = `Le fichier ne respecte pas le format décrit dans <a href="https://betagouv.github.io/pitchou/projet-pitchou/technique/fichier-especes-ods" target="_blank" rel="noopener external" title="Lien vers la page qui renseigne sur le format d\'un fichier espèces - nouvelle fenêtre">la documentation des fichiers d'espèces.</a>`
+                    messageErreurPréRemplirAvecDocumentOds = `Le fichier ne respecte pas le format décrit dans <a href="https://betagouv.github.io/pitchou/projet-pitchou/technique/fichier-especes-ods" target="_blank" rel="noopener external" title="documentation des fichiers d'espèces – nouvelle fenêtre">la documentation des fichiers d'espèces.</a>`
                 } else {
                     messageErreurPréRemplirAvecDocumentOds = erreur.message;
                 }

--- a/scripts/front-end/components/screens/SaisieEspèces.svelte
+++ b/scripts/front-end/components/screens/SaisieEspèces.svelte
@@ -16,6 +16,7 @@
     import {normalizeNomEspèce, normalizeTexteEspèce} from '../../../commun/manipulationStrings.js'
     import { descriptionMenacesEspècesToOdsArrayBuffer } from '../../../commun/outils-espèces.js'
 
+
     /** @import { ParClassification, EspèceProtégée, OiseauAtteint, FauneNonOiseauAtteinte, FloreAtteinte} from '../../../types/especes.d.ts' **/
     /** @import { ActivitéMenançante, MéthodeMenançante, TransportMenançant, DescriptionMenacesEspèces } from '../../../types/especes.d.ts' **/
 
@@ -47,6 +48,8 @@
     } = $props();
 
     let nombreEspècesSaisies = $derived(oiseauxAtteints.length + faunesNonOiseauxAtteintes.length + floresAtteintes.length)
+    /** @type {File | undefined} */
+    let file = $state()
 
     function rerender(){
         oiseauxAtteints = oiseauxAtteints
@@ -86,17 +89,27 @@
     async function onFileInput(e){
         /** @type {FileList | null} */
         const files = e.currentTarget.files
-        const file = files && files[0]
+        file = files && files[0] || undefined
+    }
 
+    async function onClickPréRemplirAvecDocumentOds(){
         if(file){
             const descriptionMenacesEspèces = await file.arrayBuffer()
                 .then(importDescriptionMenacesEspècesFromOds)
 
-            if(descriptionMenacesEspèces){
+            if(Object.keys(descriptionMenacesEspèces).length >= 1){
                 oiseauxAtteints = descriptionMenacesEspèces['oiseau'] || []
                 faunesNonOiseauxAtteintes = descriptionMenacesEspèces['faune non-oiseau'] || []
                 floresAtteintes = descriptionMenacesEspèces['flore'] || []
+
+                const modale = document.querySelector('#modale-préremplir-depuis-import');
+                if (modale) {
+                    //@ts-ignore
+                    window.dsfr(modale).modal.conceal();
+                }
             }
+        } else {
+            console.warn("Aucun fichier espèces .ods n'a été téléchargé.")
         }
     }
 
@@ -294,18 +307,41 @@
                                         <button aria-controls="modale-préremplir-depuis-import" title="Fermer" type="button" class="fr-btn--close fr-btn">Fermer</button>
                                     </div>
                                     <div class="fr-modal__content">
-                                        <h2 id="modale-préremplir-depuis-import-title" class="fr-modal__title">
-                                            Pré-remplir avec une liste déjà réalisée
-                                        </h2>
-                                        <div class="fr-mb-4w"> 
-                                            <div class="fr-upload-group">
-                                                <label class="fr-label" for="file-upload">Importer un fichier d'espèces
-                                                    <span class="fr-hint-text">Taille maximale : 100 Mo. Formats supportés : ods</span>
-                                                </label>
-                                                <input oninput={onFileInput} class="fr-upload" type="file" accept=".ods" id="file-upload" name="file-upload">
-                                            </div>
-                                        </div>
+										<h2 id="modale-préremplir-depuis-import-title" class="fr-modal__title">
+											Pré-remplir avec une liste déjà réalisée
+										</h2>
+										<div class="fr-mb-4w">
+                                            <span class="fr-text--sm">
+                                                Vous pouvez choisir : 
+                                                <ul>
+                                                    <li>
+                                                        un document déjà généré avec cet outil
+                                                    </li>
+                                                    <li>
+                                                        un document .ods qui respecte la nomenclature décrite <a href="https://betagouv.github.io/pitchou/projet-pitchou/technique/fichier-especes-ods" target="_blank" rel="noopener external" title="Lien vers la page de nomenclature - nouvelle fenêtre" class="fr-link">sur cette page</a>
+                                                    </li>
+                                                </ul>
+                                            </span>
+											<div class="fr-upload-group">
+												<label class="fr-label" for="file-upload">
+													<span class="fr-hint-text">Taille maximale : 100 Mo. Formats supportés : ods</span>
+												</label>
+												<input
+													aria-label="Importer un fichier d'espèces"
+													oninput={onFileInput}
+													class="fr-upload"
+													type="file"
+													accept=".ods"
+													id="file-upload"
+													name="file-upload" />
+											</div>
+										</div>
                                     </div>
+									<div class="fr-modal__footer">
+                                        <button class="fr-btn fr-ml-auto" onclick={onClickPréRemplirAvecDocumentOds}>
+                                            Pré-remplir
+                                        </button>
+									</div>
                                 </div>
                             </div>
                         </div>
@@ -591,6 +627,12 @@
         }
 
         .préremplir-espèces{
+            ul{
+                list-style: '- ';
+            }
+        }
+
+        #modale-préremplir-depuis-import{
             ul{
                 list-style: '- ';
             }

--- a/scripts/front-end/components/screens/SaisieEspèces.svelte
+++ b/scripts/front-end/components/screens/SaisieEspèces.svelte
@@ -49,7 +49,7 @@
 
     let nombreEspècesSaisies = $derived(oiseauxAtteints.length + faunesNonOiseauxAtteintes.length + floresAtteintes.length)
     /** @type {File | undefined} */
-    let file = $state()
+    let fichierEspècesOds = $state()
 
     function rerender(){
         oiseauxAtteints = oiseauxAtteints
@@ -89,12 +89,12 @@
     async function onFileInput(e){
         /** @type {FileList | null} */
         const files = e.currentTarget.files
-        file = files && files[0] || undefined
+        fichierEspècesOds = files && files[0] || undefined
     }
 
     async function onClickPréRemplirAvecDocumentOds(){
-        if(file){
-            const descriptionMenacesEspèces = await file.arrayBuffer()
+        if(fichierEspècesOds){
+            const descriptionMenacesEspèces = await fichierEspècesOds.arrayBuffer()
                 .then(importDescriptionMenacesEspècesFromOds)
 
             if(Object.keys(descriptionMenacesEspèces).length >= 1){

--- a/scripts/front-end/components/screens/SaisieEspèces.svelte
+++ b/scripts/front-end/components/screens/SaisieEspèces.svelte
@@ -54,6 +54,9 @@
     /** @type {string | undefined} */
     let messageErreurPréRemplirAvecDocumentOds = $state()
 
+    /** @type {HTMLInputElement | undefined} */
+    let inputFileUpload = $state()
+
     function rerender(){
         oiseauxAtteints = oiseauxAtteints
         faunesNonOiseauxAtteintes = faunesNonOiseauxAtteintes
@@ -97,6 +100,8 @@
 
     async function onClickPréRemplirAvecDocumentOds(){
         try {
+            // Comme le fichier est bien téléchargé avec le bon format quand on arrive ici, on s'assure que la variable contenant le message d'erreur est undefined.
+            messageErreurPréRemplirAvecDocumentOds = undefined
             if(!fichierEspècesOds){
                 throw new Error("Aucun fichier espèces .ods n'a été téléchargé.")
             }
@@ -114,8 +119,6 @@
                     window.dsfr(modale).modal.conceal();
                 }
             }
-            // Comme le fichier est bien téléchargé avec le bon format quand on arrive ici, on s'assure que la variable contenant le message d'erreur est undefined.
-            messageErreurPréRemplirAvecDocumentOds = undefined
         } catch (erreur) {
             messageErreurPréRemplirAvecDocumentOds = "Une erreur est survenue au moment de cliquer sur le bouton Pré-remplir.";
             if (erreur instanceof Error) {
@@ -124,6 +127,10 @@
                 } else {
                     messageErreurPréRemplirAvecDocumentOds = erreur.message;
                 }
+            }
+            // Déplacer le focus sur le champ de fichier en cas d'erreur
+            if (inputFileUpload) {
+                inputFileUpload.focus();
             }
             throw new Error(messageErreurPréRemplirAvecDocumentOds)
         }
@@ -343,6 +350,7 @@
 													<span class="fr-hint-text">Taille maximale : 100 Mo. Formats supportés : ods</span>
 												</label>
 												<input
+													bind:this={inputFileUpload}
 													aria-label="Importer un fichier d'espèces"
 													oninput={onFileInput}
 													class="fr-upload"


### PR DESCRIPTION
1. Intégrer le bon texte conformément à la maquette
2. Rajouter un bouton pour lancer l'action de Pré-remplir
3. Rajouter des warnings pour rendre compte de l'absence de fichier ou d'un fichier mal formatté

J'ai rajouté deux console.warn
- Un pour signaler qu'aucun fichier n'a été téléchargé
- Un pour signaler que le format du fichier importé semble incorrect

L'intention derrière ces consoles warn c'est de les "transformer" plus tard en message visible pour les utilisateurices


----
Edit 20/10

Suite à discussion avec David et Maïtané, Ajout d'un message d'erreur au moment d'appuyer sur Pré-remplir lorsque : 
- pas de fichier téléchargé
- fichier espèce au format incorrect (format incorrect = ods mais avec les mauvais noms de colonnes)
