### PR TITLE
Renommer Transport par Moyen de poursuite

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
     <link rel="manifest" href="/public/favicon/manifest.webmanifest" crossorigin="use-credentials">
 
     <link id="especes-data" href="/data/liste-espèces-protégées.csv" crossorigin="anonymous">
-    <link id="activites-methodes-transports-data" href="/data/activites-methodes-moyens-de-poursuite.ods" crossorigin="anonymous">
+    <link id="activites-methodes-moyens-de-poursuite-data" href="/data/activites-methodes-moyens-de-poursuite.ods" crossorigin="anonymous">
     <link
         id="schema-DS8844"
         href="/data/démarches-simplifiées/schema-DS/derogation-especes-protegees.json"

--- a/outils/generation-message-geomce.js
+++ b/outils/generation-message-geomce.js
@@ -5,7 +5,7 @@ import * as csv from 'csv-parse/sync'
 import parseArgs from 'minimist'
 
 import { directDatabaseConnection, closeDatabaseConnection } from '../scripts/server/database.js';
-import { construireActivitésMéthodesTransports, espèceProtégéeStringToEspèceProtégée, importDescriptionMenacesEspècesFromOdsArrayBuffer } from '../scripts/commun/outils-espèces.js';
+import { construireActivitésMéthodesMoyensDePoursuite, espèceProtégéeStringToEspèceProtégée, importDescriptionMenacesEspècesFromOdsArrayBuffer } from '../scripts/commun/outils-espèces.js';
 
 /** @import {default as Dossier} from '../scripts/types/database/public/Dossier.ts' */
 /** @import { GeoMceMessage, DossierPourGeoMCE } from '../scripts/types/geomce.ts' */
@@ -15,11 +15,11 @@ import { construireActivitésMéthodesTransports, espèceProtégéeStringToEspè
 const DATA_DIR = path.join(import.meta.dirname, '../data')
 
 /**
- * @returns {Promise<NonNullable<PitchouState['activitésMéthodesTransports']>> }
+ * @returns {Promise<NonNullable<PitchouState['ActivitésMéthodesMoyensDePoursuite']>> }
  */
-async function chargerActivitésMéthodesTransports() {
+async function chargerActivitésMéthodesMoyensDePoursuite() {
     const activitésBuffer = await fs.readFile(path.join(DATA_DIR, 'activites-methodes-moyens-de-poursuite.ods'))
-    return await construireActivitésMéthodesTransports(activitésBuffer)
+    return await construireActivitésMéthodesMoyensDePoursuite(activitésBuffer)
 }
 
 /**
@@ -70,7 +70,7 @@ async function récupérerDossierParId(idDossier) {
     const [dossier, instructeurs] = await Promise.all([dossierP, instructeursP])
 
     const espèceParCD_REF = await chargerListeEspèceParCD_REF()
-    const { activités, méthodes, transports } = await chargerActivitésMéthodesTransports()
+    const { activités, méthodes, transports } = await chargerActivitésMéthodesMoyensDePoursuite()
 
     const descriptionEspèces = await importDescriptionMenacesEspècesFromOdsArrayBuffer(
         dossier.fichier_contenu,

--- a/outils/generation-message-geomce.js
+++ b/outils/generation-message-geomce.js
@@ -70,14 +70,14 @@ async function récupérerDossierParId(idDossier) {
     const [dossier, instructeurs] = await Promise.all([dossierP, instructeursP])
 
     const espèceParCD_REF = await chargerListeEspèceParCD_REF()
-    const { activités, méthodes, transports } = await chargerActivitésMéthodesMoyensDePoursuite()
+    const { activités, méthodes, moyensDePoursuite } = await chargerActivitésMéthodesMoyensDePoursuite()
 
     const descriptionEspèces = await importDescriptionMenacesEspècesFromOdsArrayBuffer(
         dossier.fichier_contenu,
         espèceParCD_REF,
         activités,
         méthodes,
-        transports
+        moyensDePoursuite
     )
 
     return {

--- a/scripts/commun/outils-espèces.js
+++ b/scripts/commun/outils-espèces.js
@@ -470,48 +470,48 @@ async function importDescriptionMenacesEspècesFromOdsArrayBuffer_version_1(odsF
 
 /**
  * @param {Buffer} odsData
- * @returns {Promise<NonNullable<PitchouState['activitésMéthodesTransports']>> }
+ * @returns {Promise<NonNullable<PitchouState['ActivitésMéthodesMoyensDePoursuite']>> }
  */
-export async function construireActivitésMéthodesTransports(odsData) {
-    const activitésMéthodesTransportsBruts = await getODSTableRawContent(odsData).then(tableRawContentToObjects)
+export async function construireActivitésMéthodesMoyensDePoursuite(odsData) {
+    const ActivitésMéthodesMoyensDePoursuiteBruts = await getODSTableRawContent(odsData).then(tableRawContentToObjects)
 
     // Les lignes sont réassignées dans des nouveaux objets pour qu'ils aient la méthode `Object.prototype.toString`
     // utilisée par Svelte
 
     /**  @type {ParClassification<ActivitéMenançante[]>} */
     const activitésBrutes = {
-        oiseau: activitésMéthodesTransportsBruts.get("Activités oiseau").map(
+        oiseau: ActivitésMéthodesMoyensDePoursuiteBruts.get("Activités oiseau").map(
             // @ts-ignore
             row => Object.assign({}, row)
         ),
-        "faune non-oiseau": activitésMéthodesTransportsBruts.get("Activités faune non oiseau").map(
+        "faune non-oiseau": ActivitésMéthodesMoyensDePoursuiteBruts.get("Activités faune non oiseau").map(
             // @ts-ignore
             row => Object.assign({}, row)
         ),
-        flore: activitésMéthodesTransportsBruts.get("Activités flore").map(
+        flore: ActivitésMéthodesMoyensDePoursuiteBruts.get("Activités flore").map(
             // @ts-ignore
             row => Object.assign({}, row)
         ),
     }
 
     /** @type { MéthodeMenançante[] } */
-    const méthodesBrutes = activitésMéthodesTransportsBruts.get("Méthodes").map(
+    const méthodesBrutes = ActivitésMéthodesMoyensDePoursuiteBruts.get("Méthodes").map(
         // @ts-ignore
         row => Object.assign({}, row)
     )
     /** @type { MoyenDePoursuiteMenaçant[] } */
-    const moyensPoursuite = activitésMéthodesTransportsBruts.get("Moyens de poursuite").map(
+    const moyensPoursuite = ActivitésMéthodesMoyensDePoursuiteBruts.get("Moyens de poursuite").map(
         // @ts-ignore
         row => Object.assign({}, row)
     )
 
-    const activitésMéthodesTransports = actMetTransArraysToMapBundle(
+    const ActivitésMéthodesMoyensDePoursuite = actMetTransArraysToMapBundle(
         activitésBrutes,
         méthodesBrutes,
         moyensPoursuite
     )
 
-    const identifiantPitchouVersActivitéEtImpactsQuantifiés = new Map(Object.values(activitésMéthodesTransports.activités)
+    const identifiantPitchouVersActivitéEtImpactsQuantifiés = new Map(Object.values(ActivitésMéthodesMoyensDePoursuite.activités)
         .flatMap((activités) => {
             return [...activités.entries()].map(([code, activité]) => {
                 /** @type {ImpactQuantifié[]} */
@@ -529,7 +529,7 @@ export async function construireActivitésMéthodesTransports(odsData) {
 
     const ret = {
         identifiantPitchouVersActivitéEtImpactsQuantifiés,
-        ...activitésMéthodesTransports
+        ...ActivitésMéthodesMoyensDePoursuite
     }
 
     return ret

--- a/scripts/commun/outils-espèces.js
+++ b/scripts/commun/outils-espèces.js
@@ -538,17 +538,17 @@ export async function construireActivitésMéthodesMoyensDePoursuite(odsData) {
 /**
  * @param {ParClassification<ActivitéMenançante[]>} activitésBrutes
  * @param {MéthodeMenançante[]} méthodesBrutes
- * @param {MoyenDePoursuiteMenaçant[]} transportsBruts
+ * @param {MoyenDePoursuiteMenaçant[]} moyensDePoursuiteBruts
  *
  * @returns {{
 *  activités: ParClassification<Map<ActivitéMenançante['Identifiant Pitchou'], ActivitéMenançante>>,
 *  méthodes: ParClassification<Map<MéthodeMenançante['Code'], MéthodeMenançante>>,
-*  transports: ParClassification<Map<MoyenDePoursuiteMenaçant['Code'], MoyenDePoursuiteMenaçant>>
+*  moyensDePoursuite: ParClassification<Map<MoyenDePoursuiteMenaçant['Code'], MoyenDePoursuiteMenaçant>>
 * }}
 */
 
 
-export function actMetTransArraysToMapBundle(activitésBrutes, méthodesBrutes, transportsBruts){
+export function actMetTransArraysToMapBundle(activitésBrutes, méthodesBrutes, moyensDePoursuiteBruts){
     /** @type {ParClassification<Map<ActivitéMenançante['Code rapportage européen'], ActivitéMenançante>>} */
     const activités = {
         oiseau: new Map(),
@@ -607,7 +607,7 @@ export function actMetTransArraysToMapBundle(activitésBrutes, méthodesBrutes, 
        flore: new Map()
    };
 
-   for(const transport of transportsBruts){
+   for(const transport of moyensDePoursuiteBruts){
        const classif = transport['Espèces']
 
        if(!classif.trim() && (transport['Code'] === undefined || transport['Code'] === '')){
@@ -630,7 +630,7 @@ export function actMetTransArraysToMapBundle(activitésBrutes, méthodesBrutes, 
    return {
        activités,
        méthodes,
-       transports
+       moyensDePoursuite: transports
    }
 }
 

--- a/scripts/commun/outils-espèces.js
+++ b/scripts/commun/outils-espèces.js
@@ -14,7 +14,7 @@ import {createOdsFile, getODSTableRawContent, tableRawContentToObjects} from '@o
  *    DescriptionMenaceEspèceJSON,
  *    ActivitéMenançante,
  *    MéthodeMenançante,
- *    TransportMenançant,
+ *    MoyenDePoursuiteMenaçant,
  *    ImpactQuantifié,
  * } from "../types/especes.d.ts" */
 /** @import {SheetRawContent, SheetRawCellContent} from '@odfjs/odfjs' */
@@ -242,7 +242,7 @@ export function descriptionMenacesEspècesToOdsArrayBuffer(descriptionMenacesEsp
  * @param {Map<EspèceProtégée['CD_REF'], EspèceProtégée>} espèceByCD_REF
  * @param {ParClassification<Map<ActivitéMenançante['Identifiant Pitchou'], ActivitéMenançante>>} activites
  * @param {ParClassification<Map<MéthodeMenançante['Code'], MéthodeMenançante>>} methodes
- * @param {ParClassification<Map<TransportMenançant['Code'], TransportMenançant>>} transports
+ * @param {ParClassification<Map<MoyenDePoursuiteMenaçant['Code'], MoyenDePoursuiteMenaçant>>} transports
  * @returns {DescriptionMenacesEspèces}
  */
 function descriptionMenacesEspècesFromJSON(descriptionMenacesEspècesJSON, espèceByCD_REF, activites, methodes, transports){
@@ -287,7 +287,7 @@ function b64ToUTF8(s) {
  * @param {Map<EspèceProtégée['CD_REF'], EspèceProtégée>} espèceByCD_REF
  * @param {ParClassification<Map<ActivitéMenançante['Identifiant Pitchou'], ActivitéMenançante>>} activites
  * @param {ParClassification<Map<MéthodeMenançante['Code'], MéthodeMenançante>>} methodes
- * @param {ParClassification<Map<TransportMenançant['Code'], TransportMenançant>>} transports
+ * @param {ParClassification<Map<MoyenDePoursuiteMenaçant['Code'], MoyenDePoursuiteMenaçant>>} transports
  * @returns {DescriptionMenacesEspèces | undefined}
  */
 export function importDescriptionMenacesEspècesFromURL(url, espèceByCD_REF, activites, methodes, transports){
@@ -320,7 +320,7 @@ function ligneEspèceImpactéeHasCD_REF(espèceImpactée){
  * @param {Map<EspèceProtégée['CD_REF'], EspèceProtégée>} espèceByCD_REF
  * @param {ParClassification<Map<ActivitéMenançante['Identifiant Pitchou'], ActivitéMenançante>>} activites
  * @param {ParClassification<Map<MéthodeMenançante['Code'], MéthodeMenançante>>} methodes
- * @param {ParClassification<Map<TransportMenançant['Code'], TransportMenançant>>} transports
+ * @param {ParClassification<Map<MoyenDePoursuiteMenaçant['Code'], MoyenDePoursuiteMenaçant>>} transports
  * @returns {Promise<DescriptionMenacesEspèces>}
  */
 async function importDescriptionMenacesEspècesFromOdsArrayBuffer_version_1(odsFile, espèceByCD_REF, activites, methodes, transports){
@@ -499,7 +499,7 @@ export async function construireActivitésMéthodesTransports(odsData) {
         // @ts-ignore
         row => Object.assign({}, row)
     )
-    /** @type { TransportMenançant[] } */
+    /** @type { MoyenDePoursuiteMenaçant[] } */
     const moyensPoursuite = activitésMéthodesTransportsBruts.get("Moyens de poursuite").map(
         // @ts-ignore
         row => Object.assign({}, row)
@@ -538,12 +538,12 @@ export async function construireActivitésMéthodesTransports(odsData) {
 /**
  * @param {ParClassification<ActivitéMenançante[]>} activitésBrutes
  * @param {MéthodeMenançante[]} méthodesBrutes
- * @param {TransportMenançant[]} transportsBruts
+ * @param {MoyenDePoursuiteMenaçant[]} transportsBruts
  *
  * @returns {{
 *  activités: ParClassification<Map<ActivitéMenançante['Identifiant Pitchou'], ActivitéMenançante>>,
 *  méthodes: ParClassification<Map<MéthodeMenançante['Code'], MéthodeMenançante>>,
-*  transports: ParClassification<Map<TransportMenançant['Code'], TransportMenançant>>
+*  transports: ParClassification<Map<MoyenDePoursuiteMenaçant['Code'], MoyenDePoursuiteMenaçant>>
 * }}
 */
 
@@ -600,7 +600,7 @@ export function actMetTransArraysToMapBundle(activitésBrutes, méthodesBrutes, 
        méthodes[classif] = classifMeth
    }
 
-   /** @type {ParClassification<Map<TransportMenançant['Code'], TransportMenançant>>} */
+   /** @type {ParClassification<Map<MoyenDePoursuiteMenaçant['Code'], MoyenDePoursuiteMenaçant>>} */
    const transports = {
        oiseau: new Map(),
        "faune non-oiseau": new Map(),

--- a/scripts/front-end/actions/activitésMéthodesMoyensDePoursuite.js
+++ b/scripts/front-end/actions/activitésMéthodesMoyensDePoursuite.js
@@ -1,14 +1,14 @@
 //@ts-check
 
 import {dsv, buffer} from 'd3-fetch'
-import store from "../store"
+import store from "../store.js"
 import { getURL } from '../getLinkURL.js';
-import { espèceProtégéeStringToEspèceProtégée, actMetTransArraysToMapBundle, isClassif, construireActivitésMéthodesTransports } from '../../commun/outils-espèces.js';
+import { espèceProtégéeStringToEspèceProtégée, actMetTransArraysToMapBundle, isClassif, construireActivitésMéthodesMoyensDePoursuite } from '../../commun/outils-espèces.js';
 
 //@ts-ignore
 /** @import {PitchouState} from '../store.js' */
 //@ts-ignore
-/** @import {ParClassification, ActivitéMenançante, EspèceProtégée, MéthodeMenançante, MoyenDePoursuiteMenaçant, DescriptionMenacesEspèces, CodeActivitéStandard, CodeActivitéPitchou, ImpactQuantifié} from '../../types/especes.d.ts' */
+/** @import {ParClassification, ActivitéMenançante, EspèceProtégée, MéthodeMenançante, MoyenDePoursuiteMenaçant, DescriptionMenacesEspèces, CodeActivitéStandard, CodeActivitéPitchou, ImpactQuantifié} from '../../types/especes' */
 
 
 /**
@@ -60,7 +60,7 @@ export async function chargerListeEspècesProtégées(){
 
 /**
  * Charge et organise données concernant les activités, méthodes et transports depuis les fichiers CSV externes.
- * @returns {Promise<NonNullable<PitchouState['activitésMéthodesTransports']>>}
+ * @returns {Promise<NonNullable<PitchouState['ActivitésMéthodesMoyensDePoursuite']>>}
  * - activités : Map indexée par classification d'espèce (oiseau, faune non-oiseau, flore) contenant les activités menaçantes indexées par leur code
  * - méthodes : Map indexée par classification d'espèce contenant les méthodes menaçantes indexées par leur code
  * - transports : Map indexée par classification d'espèce contenant les transports menaçants indexés par leur code
@@ -76,17 +76,17 @@ export async function chargerListeEspècesProtégées(){
  * @see {@link https://dd.eionet.europa.eu/schemas/habides-2.0/derogations.xsd}
  * Référence du schéma XML de la directive Habides 2.0, définissant les types d’activités.
  */
-export async function chargerActivitésMéthodesTransports(){
+export async function chargerActivitésMéthodesMoyensDePoursuite(){
 
-    if(store.state.activitésMéthodesTransports){
-        return Promise.resolve(store.state.activitésMéthodesTransports)
+    if(store.state.ActivitésMéthodesMoyensDePoursuite){
+        return Promise.resolve(store.state.ActivitésMéthodesMoyensDePoursuite)
     }
 
     const odsData = await buffer(getURL('link#activites-methodes-moyens-de-poursuite-data'))
     // @ts-ignore
-    const ret = await construireActivitésMéthodesTransports(odsData)
+    const ret = await construireActivitésMéthodesMoyensDePoursuite(odsData)
 
-    store.mutations.setActivitésMéthodesTransports(ret)
+    store.mutations.setActivitésMéthodesMoyensDePoursuite(ret)
 
     return ret
 }

--- a/scripts/front-end/actions/activitésMéthodesTransports.js
+++ b/scripts/front-end/actions/activitésMéthodesTransports.js
@@ -82,7 +82,7 @@ export async function chargerActivitésMéthodesTransports(){
         return Promise.resolve(store.state.activitésMéthodesTransports)
     }
 
-    const odsData = await buffer(getURL('link#activites-methodes-transports-data'))
+    const odsData = await buffer(getURL('link#activites-methodes-moyens-de-poursuite-data'))
     // @ts-ignore
     const ret = await construireActivitésMéthodesTransports(odsData)
 

--- a/scripts/front-end/actions/activitésMéthodesTransports.js
+++ b/scripts/front-end/actions/activitésMéthodesTransports.js
@@ -8,7 +8,7 @@ import { espèceProtégéeStringToEspèceProtégée, actMetTransArraysToMapBundl
 //@ts-ignore
 /** @import {PitchouState} from '../store.js' */
 //@ts-ignore
-/** @import {ParClassification, ActivitéMenançante, EspèceProtégée, MéthodeMenançante, TransportMenançant, DescriptionMenacesEspèces, CodeActivitéStandard, CodeActivitéPitchou, ImpactQuantifié} from '../../types/especes.d.ts' */
+/** @import {ParClassification, ActivitéMenançante, EspèceProtégée, MéthodeMenançante, MoyenDePoursuiteMenaçant, DescriptionMenacesEspèces, CodeActivitéStandard, CodeActivitéPitchou, ImpactQuantifié} from '../../types/especes.d.ts' */
 
 
 /**

--- a/scripts/front-end/actions/dossier.js
+++ b/scripts/front-end/actions/dossier.js
@@ -106,14 +106,14 @@ export async function espècesImpactéesDepuisFichierOdsArrayBuffer(fichierArray
     const actMétTrans = chargerActivitésMéthodesMoyensDePoursuite()
 
     const {espèceByCD_REF} = await espècesProtégées
-    const { activités, méthodes, transports } = await actMétTrans
+    const { activités, méthodes, moyensDePoursuite } = await actMétTrans
 
     return importDescriptionMenacesEspècesFromOdsArrayBuffer(
         fichierArrayBuffer,
         espèceByCD_REF,
         activités,
         méthodes,
-        transports
+        moyensDePoursuite
     )
 
 }

--- a/scripts/front-end/actions/dossier.js
+++ b/scripts/front-end/actions/dossier.js
@@ -14,7 +14,7 @@ import { chargerRelationSuivi } from "./main.js";
 //@ts-ignore
 /** @import {default as Message} from '../../types/database/public/Message.ts' */
 //@ts-ignore
-/** @import {ParClassification, ActivitéMenançante, EspèceProtégée, MéthodeMenançante, TransportMenançant, DescriptionMenacesEspèces, CodeActivitéStandard, CodeActivitéPitchou} from '../../types/especes.d.ts' */
+/** @import {ParClassification, ActivitéMenançante, EspèceProtégée, MéthodeMenançante, MoyenDePoursuiteMenaçant, DescriptionMenacesEspèces, CodeActivitéStandard, CodeActivitéPitchou} from '../../types/especes.d.ts' */
 
 /**
  * @param {DossierComplet} dossier

--- a/scripts/front-end/actions/dossier.js
+++ b/scripts/front-end/actions/dossier.js
@@ -3,7 +3,7 @@
 import store from "../store"
 
 import { importDescriptionMenacesEspècesFromOdsArrayBuffer } from '../../commun/outils-espèces.js';
-import { chargerActivitésMéthodesTransports, chargerListeEspècesProtégées } from './activitésMéthodesTransports.js';
+import { chargerActivitésMéthodesMoyensDePoursuite, chargerListeEspècesProtégées } from './activitésMéthodesMoyensDePoursuite.js';
 import { isDossierRésuméArray } from '../../types/typeguards.js';
 import { chargerRelationSuivi } from "./main.js";
 
@@ -103,7 +103,7 @@ export async function refreshDossierComplet(id){
  */
 export async function espècesImpactéesDepuisFichierOdsArrayBuffer(fichierArrayBuffer){
     const espècesProtégées = chargerListeEspècesProtégées()
-    const actMétTrans = chargerActivitésMéthodesTransports()
+    const actMétTrans = chargerActivitésMéthodesMoyensDePoursuite()
 
     const {espèceByCD_REF} = await espècesProtégées
     const { activités, méthodes, transports } = await actMétTrans

--- a/scripts/front-end/components/Dossier/DossierGénérationDocuments.svelte
+++ b/scripts/front-end/components/Dossier/DossierGénérationDocuments.svelte
@@ -1,7 +1,7 @@
 <script>
     import {fillOdtTemplate, getOdtTextContent} from '@odfjs/odfjs'
     import {getBalisesGénérationDocument} from '../../../front-end/actions/générerDocument.js'
-    import { chargerActivitésMéthodesTransports } from '../../actions/activitésMéthodesTransports.js';
+    import { chargerActivitésMéthodesMoyensDePoursuite } from '../../actions/activitésMéthodesMoyensDePoursuite.js';
 
     /** @import {DossierComplet} from '../../../types/API_Pitchou' */
     /** @import {DescriptionMenacesEspèces} from '../../../types/especes.d.ts' */
@@ -51,7 +51,7 @@
 
         let espèces_impacts = undefined
 
-        const { identifiantPitchouVersActivitéEtImpactsQuantifiés } = await chargerActivitésMéthodesTransports()
+        const { identifiantPitchouVersActivitéEtImpactsQuantifiés } = await chargerActivitésMéthodesMoyensDePoursuite()
 
         try{
             // on laisse les erreurs sortir silencieusement ici s'il y en a

--- a/scripts/front-end/components/Dossier/DossierProjet.svelte
+++ b/scripts/front-end/components/Dossier/DossierProjet.svelte
@@ -3,7 +3,7 @@
     import DownloadButton from "../DownloadButton.svelte";
     import EspècesProtégéesGroupéesParImpact from "../EspècesProtégéesGroupéesParImpact.svelte";
     import { formatDateRelative } from "../../affichageDossier.js";
-    import { chargerActivitésMéthodesTransports } from "../../actions/activitésMéthodesTransports.js";
+    import { chargerActivitésMéthodesMoyensDePoursuite } from "../../actions/activitésMéthodesMoyensDePoursuite.js";
 	import Loader from "../Loader.svelte"
 	import { originDémarcheNumérique } from "../../../commun/constantes.js"
 
@@ -37,7 +37,7 @@
         return dossier.espècesImpactées?.nom || "fichier";
     }
 
-    const promesseRéférentiels = chargerActivitésMéthodesTransports();
+    const promesseRéférentiels = chargerActivitésMéthodesMoyensDePoursuite();
 
     /** @type {{nom_complet:string,qualification:string}[]| undefined} */
     // @ts-ignore

--- a/scripts/front-end/components/SaisieEspèces/FormulaireSaisieEspèce.svelte
+++ b/scripts/front-end/components/SaisieEspèces/FormulaireSaisieEspèce.svelte
@@ -3,7 +3,7 @@
     import TuileSaisieEspèce from '../SaisieEspèces/TuileSaisieEspèce.svelte'
 	import { mailtoJeNetrouvePasUneEspèce } from '../../../commun/constantes.js'
 
-    /** @import {ParClassification, EspèceProtégée, DescriptionImpact, ActivitéMenançante, MéthodeMenançante, TransportMenançant} from "../../../types/especes.js" */
+    /** @import {ParClassification, EspèceProtégée, DescriptionImpact, ActivitéMenançante, MéthodeMenançante, MoyenDePoursuiteMenaçant} from "../../../types/especes.js" */
 
 
     /**
@@ -14,7 +14,7 @@
      * @property {TuileSaisieEspèce[]} référencesEspèces
      * @property {ParClassification<Map<ActivitéMenançante['Identifiant Pitchou'], ActivitéMenançante>>} [activitesParClassificationEtreVivant]
      * @property {ParClassification<Map<MéthodeMenançante['Code'], MéthodeMenançante>>} méthodesParClassificationEtreVivant
-     * @property {ParClassification<Map<TransportMenançant['Code'], TransportMenançant>>} transportsParClassificationEtreVivant
+     * @property {ParClassification<Map<MoyenDePoursuiteMenaçant['Code'], MoyenDePoursuiteMenaçant>>} transportsParClassificationEtreVivant
      */
 
     /** @type {Props} */

--- a/scripts/front-end/components/SaisieEspèces/ImpactEspèce.svelte
+++ b/scripts/front-end/components/SaisieEspèces/ImpactEspèce.svelte
@@ -3,7 +3,7 @@
 
     import { fourchettesIndividus } from "../../espèceFieldset.js";
 
-    /** @import {ParClassification, DescriptionImpact, EspèceProtégée, ActivitéMenançante, MéthodeMenançante, TransportMenançant, ClassificationEtreVivant} from "../../../types/especes.js" */
+    /** @import {ParClassification, DescriptionImpact, EspèceProtégée, ActivitéMenançante, MéthodeMenançante, MoyenDePoursuiteMenaçant, ClassificationEtreVivant} from "../../../types/especes.js" */
 
     /**
      * @typedef {Object} Props
@@ -15,7 +15,7 @@
      * @property {ClassificationEtreVivant} [espèceClassification]
      * @property {ParClassification<Map<ActivitéMenançante['Identifiant Pitchou'], ActivitéMenançante>>} [activitesParClassificationEtreVivant]
      * @property {ParClassification<Map<MéthodeMenançante['Code'], MéthodeMenançante>>} méthodesParClassificationEtreVivant
-     * @property {ParClassification<Map<TransportMenançant['Code'], TransportMenançant>>} transportsParClassificationEtreVivant
+     * @property {ParClassification<Map<MoyenDePoursuiteMenaçant['Code'], MoyenDePoursuiteMenaçant>>} transportsParClassificationEtreVivant
      */
 
     /** @type {Props} */

--- a/scripts/front-end/components/SaisieEspèces/ModalePréremplirDepuisTexte.svelte
+++ b/scripts/front-end/components/SaisieEspèces/ModalePréremplirDepuisTexte.svelte
@@ -3,7 +3,7 @@
     import EcranPréciserImpact from './ModalePréremplirDepuisTexte/EcranPréciserImpact.svelte'
     import TuileSaisieEspèce from '../SaisieEspèces/TuileSaisieEspèce.svelte'
     import { normalizeNomEspèce, normalizeTexteEspèce } from '../../../commun/manipulationStrings.js'
-    /** @import { ParClassification, EspèceProtégée, DescriptionImpact, ActivitéMenançante, MéthodeMenançante, TransportMenançant } from '../../../types/especes' **/
+    /** @import { ParClassification, EspèceProtégée, DescriptionImpact, ActivitéMenançante, MéthodeMenançante, MoyenDePoursuiteMenaçant } from '../../../types/especes' **/
 
     /**
      * @typedef {Object} Props
@@ -12,7 +12,7 @@
      * @property {(espècesImpactées: Array<{ espèce: EspèceProtégée, impacts: DescriptionImpact[] }>) => void} onClickPréRemplirAvecDocumentTexte
      * @property {ParClassification<Map<ActivitéMenançante['Identifiant Pitchou'], ActivitéMenançante>>} [activitesParClassificationEtreVivant]
      * @property {ParClassification<Map<MéthodeMenançante['Code'], MéthodeMenançante>>} méthodesParClassificationEtreVivant
-     * @property {ParClassification<Map<TransportMenançant['Code'], TransportMenançant>>} transportsParClassificationEtreVivant
+     * @property {ParClassification<Map<MoyenDePoursuiteMenaçant['Code'], MoyenDePoursuiteMenaçant>>} transportsParClassificationEtreVivant
      */
 
     /** @type {Props} */

--- a/scripts/front-end/components/SaisieEspèces/ModalePréremplirDepuisTexte/EcranPréciserImpact.svelte
+++ b/scripts/front-end/components/SaisieEspèces/ModalePréremplirDepuisTexte/EcranPréciserImpact.svelte
@@ -3,7 +3,7 @@
     import NomEspèce from '../../NomEspèce.svelte' 
     import ImpactEspèce from '../../SaisieEspèces/ImpactEspèce.svelte' 
 	import { tick } from "svelte"
-    /** @import { EspèceProtégée, DescriptionImpact, ParClassification, ActivitéMenançante, MéthodeMenançante, TransportMenançant } from '../../../../types/especes' **/
+    /** @import { EspèceProtégée, DescriptionImpact, ParClassification, ActivitéMenançante, MéthodeMenançante, MoyenDePoursuiteMenaçant } from '../../../../types/especes' **/
 
     /**
      * @typedef {Object} Props
@@ -13,7 +13,7 @@
      * @property {() => void} préremplirAvecCesEspècesImpacts
      * @property {ParClassification<Map<ActivitéMenançante['Identifiant Pitchou'], ActivitéMenançante>>} [activitesParClassificationEtreVivant]
      * @property {ParClassification<Map<MéthodeMenançante['Code'], MéthodeMenançante>>} méthodesParClassificationEtreVivant
-     * @property {ParClassification<Map<TransportMenançant['Code'], TransportMenançant>>} transportsParClassificationEtreVivant
+     * @property {ParClassification<Map<MoyenDePoursuiteMenaçant['Code'], MoyenDePoursuiteMenaçant>>} transportsParClassificationEtreVivant
      * @property {(impactPourChaqueOiseau: DescriptionImpact, impactPourChaqueFauneNonOiseau: DescriptionImpact, impactPourChaqueFlore: DescriptionImpact) => void} ajouterImpactPourChaqueClassification
      */
     /** @type {Props} */

--- a/scripts/front-end/components/SaisieEspèces/TuileSaisieEspèce.svelte
+++ b/scripts/front-end/components/SaisieEspèces/TuileSaisieEspèce.svelte
@@ -7,7 +7,7 @@
     import ImpactEspèce from './ImpactEspèce.svelte'
     import { espèceLabel } from '../../../commun/outils-espèces.js'
 
-    /** @import {ParClassification, EspèceProtégée, ActivitéMenançante, MéthodeMenançante, TransportMenançant, DescriptionImpact, ClassificationEtreVivant} from "../../../types/especes.js" */
+    /** @import {ParClassification, EspèceProtégée, ActivitéMenançante, MéthodeMenançante, MoyenDePoursuiteMenaçant, DescriptionImpact, ClassificationEtreVivant} from "../../../types/especes.js" */
 
     /**
      * @typedef {Object} Props
@@ -21,7 +21,7 @@
      * @property {EspèceProtégée[]} [espècesProtégées]
      * @property {ParClassification<Map<ActivitéMenançante['Identifiant Pitchou'], ActivitéMenançante>>} [activitesParClassificationEtreVivant]
      * @property {ParClassification<Map<MéthodeMenançante['Code'], MéthodeMenançante>>} méthodesParClassificationEtreVivant
-     * @property {ParClassification<Map<TransportMenançant['Code'], TransportMenançant>>} transportsParClassificationEtreVivant
+     * @property {ParClassification<Map<MoyenDePoursuiteMenaçant['Code'], MoyenDePoursuiteMenaçant>>} transportsParClassificationEtreVivant
      */
 
     /** @type {Props} */

--- a/scripts/front-end/components/screens/SaisieEspèces.svelte
+++ b/scripts/front-end/components/screens/SaisieEspèces.svelte
@@ -6,10 +6,10 @@
     import ModalePréremplirDepuisTexte from '../SaisieEspèces/ModalePréremplirDepuisTexte.svelte'
     import FormulaireSaisieEspèce from '../SaisieEspèces/FormulaireSaisieEspèce.svelte'
     import { descriptionMenacesEspècesToOdsArrayBuffer } from '../../../commun/outils-espèces.js'
-    import { chargerActivitésMéthodesTransports } from '../../actions/activitésMéthodesTransports.js'
     import Loader from '../Loader.svelte'
     import TuileSaisieEspèce from '../SaisieEspèces/TuileSaisieEspèce.svelte'
 	import { tick } from 'svelte'
+	import { chargerActivitésMéthodesMoyensDePoursuite } from '../../actions/activitésMéthodesMoyensDePoursuite.js'
 
 
     /** @import { ParClassification, EspèceProtégée, OiseauAtteint, FauneNonOiseauAtteinte, FloreAtteinte} from '../../../types/especes.d.ts' **/
@@ -96,7 +96,7 @@
         return espècesImpactéesParClassification
     })
 
-    const promesseRéférentiels = chargerActivitésMéthodesTransports();
+    const promesseRéférentiels = chargerActivitésMéthodesMoyensDePoursuite();
 
     /**
      * @param {DescriptionMenacesEspèces} descriptionMenacesEspèces

--- a/scripts/front-end/components/screens/SaisieEspèces.svelte
+++ b/scripts/front-end/components/screens/SaisieEspèces.svelte
@@ -12,8 +12,8 @@
 	import { tick } from 'svelte'
 
 
-    /** @import { ParClassification, DescriptionImpact, EspèceProtégée, OiseauAtteint, FauneNonOiseauAtteinte, FloreAtteinte} from '../../../types/especes.d.ts' **/
-    /** @import { ActivitéMenançante, MéthodeMenançante, TransportMenançant, DescriptionMenacesEspèces } from '../../../types/especes.d.ts' **/
+    /** @import { ParClassification, EspèceProtégée, OiseauAtteint, FauneNonOiseauAtteinte, FloreAtteinte} from '../../../types/especes.d.ts' **/
+    /** @import { ActivitéMenançante, MéthodeMenançante, MoyenDePoursuiteMenaçant, DescriptionMenacesEspèces, DescriptionImpact } from '../../../types/especes.d.ts' **/
 
 
     /**
@@ -22,7 +22,7 @@
      * @property {ParClassification<EspèceProtégée[]>} espècesProtégéesParClassification
      * @property {ParClassification<Map<ActivitéMenançante['Identifiant Pitchou'], ActivitéMenançante>>} activitesParClassificationEtreVivant
      * @property {ParClassification<Map<MéthodeMenançante['Code'], MéthodeMenançante>>} méthodesParClassificationEtreVivant
-     * @property {ParClassification<Map<TransportMenançant['Code'], TransportMenançant>>} transportsParClassificationEtreVivant
+     * @property {ParClassification<Map<MoyenDePoursuiteMenaçant['Code'], MoyenDePoursuiteMenaçant>>} transportsParClassificationEtreVivant
      * @property {(x: ArrayBuffer) => Promise<DescriptionMenacesEspèces>} importDescriptionMenacesEspècesFromOds
      * @property {OiseauAtteint[]} oiseauxAtteints
      * @property {FauneNonOiseauAtteinte[]} faunesNonOiseauxAtteintes

--- a/scripts/front-end/routes/SaisieEspèces.js
+++ b/scripts/front-end/routes/SaisieEspèces.js
@@ -21,7 +21,7 @@ export default async () => {
     const {
         activités: activitesParClassificationEtreVivant,
         méthodes: méthodesParClassificationEtreVivant,
-        transports: transportsParClassificationEtreVivant
+        moyensDePoursuite: transportsParClassificationEtreVivant
     } = await actMétTrans
 
     /**

--- a/scripts/front-end/routes/SaisieEspèces.js
+++ b/scripts/front-end/routes/SaisieEspèces.js
@@ -6,7 +6,7 @@ import { mapStateToSqueletteProps } from '../mapStateToSqueletteProps.js';
 import SaisieEspèces from '../components/screens/SaisieEspèces.svelte';
 
 import { importDescriptionMenacesEspècesFromOdsArrayBuffer, importDescriptionMenacesEspècesFromURL } from '../../commun/outils-espèces.js';
-import { chargerListeEspècesProtégées, chargerActivitésMéthodesTransports } from '../actions/activitésMéthodesTransports.js';
+import { chargerListeEspècesProtégées, chargerActivitésMéthodesMoyensDePoursuite } from '../actions/activitésMéthodesMoyensDePoursuite.js';
 
 /** @import {ComponentProps} from 'svelte' */
 
@@ -14,7 +14,7 @@ import { chargerListeEspècesProtégées, chargerActivitésMéthodesTransports }
 
 export default async () => { 
     const espècesProtégées = chargerListeEspècesProtégées()
-    const actMétTrans = chargerActivitésMéthodesTransports()
+    const actMétTrans = chargerActivitésMéthodesMoyensDePoursuite()
 
     const {espècesProtégéesParClassification, espèceByCD_REF} = await espècesProtégées
 

--- a/scripts/front-end/store.js
+++ b/scripts/front-end/store.js
@@ -38,7 +38,7 @@ import {DossierCompletToDossierRésumé} from '../commun/outils-dossiers.js'
  * @property {SchemaDémarcheSimplifiée} [schemaDS88444]
  * @property {ParClassification<EspèceProtégée[]>} [espècesProtégéesParClassification]
  * @property {Map<EspèceProtégée['CD_REF'], EspèceProtégée>} [espèceByCD_REF]
- * @property { {activités: ParClassification<Map<ActivitéMenançante['Identifiant Pitchou'], ActivitéMenançante>>, méthodes: ParClassification<Map<MéthodeMenançante['Code'],  MéthodeMenançante>>, transports: ParClassification<Map<MoyenDePoursuiteMenaçant['Code'], MoyenDePoursuiteMenaçant>>, identifiantPitchouVersActivitéEtImpactsQuantifiés: Map<string, ActivitéMenançante & {impactsQuantifiés: ImpactQuantifié[]}>} } [ActivitésMéthodesMoyensDePoursuite]
+ * @property { {activités: ParClassification<Map<ActivitéMenançante['Identifiant Pitchou'], ActivitéMenançante>>, méthodes: ParClassification<Map<MéthodeMenançante['Code'],  MéthodeMenançante>>, moyensDePoursuite: ParClassification<Map<MoyenDePoursuiteMenaçant['Code'], MoyenDePoursuiteMenaçant>>, identifiantPitchouVersActivitéEtImpactsQuantifiés: Map<string, ActivitéMenançante & {impactsQuantifiés: ImpactQuantifié[]}>} } [ActivitésMéthodesMoyensDePoursuite]
  * @property { Set<{message: string}> } erreurs
  * @property { {horodatage: Date, succès: boolean}[] } [résultatsSynchronisationDS88444]
  */

--- a/scripts/front-end/store.js
+++ b/scripts/front-end/store.js
@@ -21,7 +21,7 @@ import {DossierCompletToDossierRésumé} from '../commun/outils-dossiers.js'
 /** @import {DossierComplet, DossierRésumé} from '../types/API_Pitchou.d.ts' */
 /** @import {SchemaDémarcheSimplifiée} from '../types/démarches-simplifiées/schema.ts' */
 /** @import {PitchouInstructeurCapabilities, IdentitéInstructeurPitchou} from '../types/capabilities.d.ts' */
-/** @import {ParClassification, ActivitéMenançante, EspèceProtégée, MéthodeMenançante, TransportMenançant, ImpactQuantifié} from '../types/especes.d.ts' */
+/** @import {ParClassification, ActivitéMenançante, EspèceProtégée, MéthodeMenançante, MoyenDePoursuiteMenaçant, ImpactQuantifié} from '../types/especes.d.ts' */
 /** @import {default as Message} from '../types/database/public/Message.ts' */
 /** @import {default as Dossier} from '../types/database/public/Dossier.ts' */
 /** @import {default as Personne} from '../types/database/public/Personne.ts' */
@@ -38,7 +38,7 @@ import {DossierCompletToDossierRésumé} from '../commun/outils-dossiers.js'
  * @property {SchemaDémarcheSimplifiée} [schemaDS88444]
  * @property {ParClassification<EspèceProtégée[]>} [espècesProtégéesParClassification]
  * @property {Map<EspèceProtégée['CD_REF'], EspèceProtégée>} [espèceByCD_REF]
- * @property { {activités: ParClassification<Map<ActivitéMenançante['Identifiant Pitchou'], ActivitéMenançante>>, méthodes: ParClassification<Map<MéthodeMenançante['Code'],  MéthodeMenançante>>, transports: ParClassification<Map<TransportMenançant['Code'], TransportMenançant>>, identifiantPitchouVersActivitéEtImpactsQuantifiés: Map<string, ActivitéMenançante & {impactsQuantifiés: ImpactQuantifié[]}>} } [activitésMéthodesTransports]
+ * @property { {activités: ParClassification<Map<ActivitéMenançante['Identifiant Pitchou'], ActivitéMenançante>>, méthodes: ParClassification<Map<MéthodeMenançante['Code'],  MéthodeMenançante>>, transports: ParClassification<Map<MoyenDePoursuiteMenaçant['Code'], MoyenDePoursuiteMenaçant>>, identifiantPitchouVersActivitéEtImpactsQuantifiés: Map<string, ActivitéMenançante & {impactsQuantifiés: ImpactQuantifié[]}>} } [activitésMéthodesTransports]
  * @property { Set<{message: string}> } erreurs
  * @property { {horodatage: Date, succès: boolean}[] } [résultatsSynchronisationDS88444]
  */

--- a/scripts/front-end/store.js
+++ b/scripts/front-end/store.js
@@ -38,7 +38,7 @@ import {DossierCompletToDossierRésumé} from '../commun/outils-dossiers.js'
  * @property {SchemaDémarcheSimplifiée} [schemaDS88444]
  * @property {ParClassification<EspèceProtégée[]>} [espècesProtégéesParClassification]
  * @property {Map<EspèceProtégée['CD_REF'], EspèceProtégée>} [espèceByCD_REF]
- * @property { {activités: ParClassification<Map<ActivitéMenançante['Identifiant Pitchou'], ActivitéMenançante>>, méthodes: ParClassification<Map<MéthodeMenançante['Code'],  MéthodeMenançante>>, transports: ParClassification<Map<MoyenDePoursuiteMenaçant['Code'], MoyenDePoursuiteMenaçant>>, identifiantPitchouVersActivitéEtImpactsQuantifiés: Map<string, ActivitéMenançante & {impactsQuantifiés: ImpactQuantifié[]}>} } [activitésMéthodesTransports]
+ * @property { {activités: ParClassification<Map<ActivitéMenançante['Identifiant Pitchou'], ActivitéMenançante>>, méthodes: ParClassification<Map<MéthodeMenançante['Code'],  MéthodeMenançante>>, transports: ParClassification<Map<MoyenDePoursuiteMenaçant['Code'], MoyenDePoursuiteMenaçant>>, identifiantPitchouVersActivitéEtImpactsQuantifiés: Map<string, ActivitéMenançante & {impactsQuantifiés: ImpactQuantifié[]}>} } [ActivitésMéthodesMoyensDePoursuite]
  * @property { Set<{message: string}> } erreurs
  * @property { {horodatage: Date, succès: boolean}[] } [résultatsSynchronisationDS88444]
  */
@@ -136,10 +136,10 @@ const mutations = {
   },
   /**
    * @param {PitchouState} state
-   * @param {PitchouState['activitésMéthodesTransports']} activitésMéthodesTransports
+   * @param {PitchouState['ActivitésMéthodesMoyensDePoursuite']} ActivitésMéthodesMoyensDePoursuite
    */
-  setActivitésMéthodesTransports(state, activitésMéthodesTransports) {
-    state.activitésMéthodesTransports = activitésMéthodesTransports
+  setActivitésMéthodesMoyensDePoursuite(state, ActivitésMéthodesMoyensDePoursuite) {
+    state.ActivitésMéthodesMoyensDePoursuite = ActivitésMéthodesMoyensDePoursuite
   },
   /**
    * @param {PitchouState} state

--- a/scripts/types/especes.d.ts
+++ b/scripts/types/especes.d.ts
@@ -148,7 +148,7 @@ export interface DescriptionImpact {
     surfaceHabitatDétruit?: number,
     activité?: ActivitéMenançante,
     méthode?: MéthodeMenançante,
-    transport?: TransportMenançant,
+    transport?: MoyenDePoursuiteMenaçant,
     nombreNids?: number,
     nombreOeufs?: number,
 }

--- a/scripts/types/especes.d.ts
+++ b/scripts/types/especes.d.ts
@@ -87,7 +87,7 @@ export interface MéthodeMenançante {
     "Libellé Pitchou": string,
 }
 
-export interface TransportMenançant {
+export interface MoyenDePoursuiteMenaçant {
     Code: string,
     Espèces: ClassificationEtreVivant,
     "Libellé activité directive européenne": string,
@@ -118,7 +118,7 @@ export interface FloreAtteinteJSON extends EtreVivantAtteintJSON {
 export interface FauneNonOiseauAtteinte extends EtreVivantAtteint {
     activité?: ActivitéMenançante,
     méthode?: MéthodeMenançante,
-    transport?: TransportMenançant,
+    transport?: MoyenDePoursuiteMenaçant,
 }
 
 export interface FauneNonOiseauAtteinteJSON extends EtreVivantAtteintJSON {
@@ -130,7 +130,7 @@ export interface FauneNonOiseauAtteinteJSON extends EtreVivantAtteintJSON {
 export interface OiseauAtteint extends EtreVivantAtteint {
     activité?: ActivitéMenançante,
     méthode?: MéthodeMenançante,
-    transport?: TransportMenançant,
+    transport?: MoyenDePoursuiteMenaçant,
     nombreNids?: number,
     nombreOeufs?: number,
 }


### PR DESCRIPTION
Je m'arrête là pour cette PR, pour ne pas qu'il y ait trop de changements

 il reste quelques petits remplacements que j'ai documenté sur l'issue originale https://github.com/betagouv/pitchou/issues/387.
 
 Tests : 
- [X] le document `/data/activites-methodes-moyens-de-poursuite.ods` se charge bien
- [X] La saisie des espèces se fait bien, et le téléchargement du fichier
- [X] Les pages d'un dossier/page saisie des espèces s'affichent bien
- [X] svelte-check et tsc