### PR TITLE
Permettre à l'instructeurice de voir si un dossier a besoin d'une DDEP

### DIFF
--- a/scripts/front-end/components/Dossier/DossierInstruction.svelte
+++ b/scripts/front-end/components/Dossier/DossierInstruction.svelte
@@ -151,9 +151,9 @@
         {/if}
 
         <h2 class="fr-mt-3w">Une DDEP est-elle nécessaire ?</h2>
-        {#if typeof dossier.ddep_nécessaire !== 'string' || dossier.ddep_nécessaire?.length === 0}
+        {#if typeof dossier.ddep_nécessaire !== 'string' || dossier.ddep_nécessaire === ''}
             Non renseigné
-        {:else if dossier.ddep_nécessaire === 'Non'}
+        {:else}
             {dossier.ddep_nécessaire}
         {/if}
     </section>

--- a/scripts/front-end/components/Dossier/DossierInstruction.svelte
+++ b/scripts/front-end/components/Dossier/DossierInstruction.svelte
@@ -149,6 +149,13 @@
                 {/if}
             </div>
         {/if}
+
+        <h2 class="fr-mt-3w">Une DDEP est-elle nécessaire ?</h2>
+        {#if typeof dossier.ddep_nécessaire !== 'string' || dossier.ddep_nécessaire?.length === 0}
+            Non renseigné
+        {:else if dossier.ddep_nécessaire === 'Non'}
+            {dossier.ddep_nécessaire}
+        {/if}
     </section>
 
     <section>


### PR DESCRIPTION
Suite à la carte https://trello.com/c/siHqjGjZ/867-permettre-%C3%A0-linstructeurice-de-voir-si-un-dossier-a-besoin-dune-ddep

Comme pour l'instant c'est de l'affichage et ce n'est pas de la modification, je l'affiche sur la colonne de gauche de l'onglet instruction d'un dossier

<img width="965" height="703" alt="image" src="https://github.com/user-attachments/assets/01c5b54f-2191-4294-8ab2-581b16419094" />
