### PR TITLE
Bug - Liens qui redirigent vers démarches simplifiées doivent contenir le nom de domaine demarches.numeriques et pas démarches-simplifiées

### DIFF
--- a/docs/demande-de-derogation/index.md
+++ b/docs/demande-de-derogation/index.md
@@ -7,6 +7,6 @@ Cet espace fournit quelques rappels légaux, explications pratiques et conseils 
 les chances de faire aboutir votre demande de dérogation espèces protégées
 
 Selon votre département, votre demande est à déposer à un endroit différent.
-Et vous pouvez la déposer en format numérique [via le formulaire sur la plateforme Démarches Simplifiées](https://www.demarches-simplifiees.fr/commencer/derogation-especes-protegees)
+Et vous pouvez la déposer en format numérique [via le formulaire sur la plateforme Démarches Simplifiées](https://demarche.numerique.gouv.fr/commencer/derogation-especes-protegees)
 
 

--- a/docs/instruction/description-pitchou.md
+++ b/docs/instruction/description-pitchou.md
@@ -3,5 +3,5 @@
 "Pitchou" désigne plusieurs choses : 
 - le projet ("startup d'état") qui se donne pour objectif de faire respecter la règlementation sur les espèces protégées et notamment l'absence de perte nette de biodiversité. Il passe notamment par améliorer le process d'instruction et augmenter les contrôles sur le terrain pour avoir une meilleure visibilité de l'effet des dérogations sur la biodiversité en France
 - la plateforme [pitchou.beta.gouv.fr](https://pitchou.beta.gouv.fr/) qui fournit des outils qui facilitent le travail d'instruction et de contrôle
-    - Cette plateforme se base elle-même sur les dossiers déposés sur le formulaire sur démarche simplifié lié ([vue pétitionnaire](https://www.demarches-simplifiees.fr/commencer/derogation-especes-protegees) et [vue instructeur](https://www.demarches-simplifiees.fr/procedures/88444))
+    - Cette plateforme se base elle-même sur les dossiers déposés sur le formulaire sur démarche simplifié lié ([vue pétitionnaire](https://demarche.numerique.gouv.fr/commencer/derogation-especes-protegees) et [vue instructeur](https://demarche.numerique.gouv.fr/admin/procedures/88444))
 - la [Fauvette Pitchou *Sylvia undata*](https://fr.wikipedia.org/wiki/Fauvette_pitchou), une espèce d'oiseau protégée, présente en France métropolitaine

--- a/docs/instruction/embarquement-nouveau-service-instructeur.md
+++ b/docs/instruction/embarquement-nouveau-service-instructeur.md
@@ -7,7 +7,7 @@ Quand un service instructeur (DREAL, DDT) rejoint Pitchou, les étapes suivantes
     - préparer un calendrier d'embarquement du service
 - Suite à cette rencontre, l'équipe Pitchou créé un "groupe instructeur" pour ce service instructeur dans la procédure "démarches simplifiées" dédiée et rajoute le ou les instructeur·rices avec qui iels sont en contact dans ce groupe. Par la suite, les instructeur·rices sont automone et peuvent gérer leur groupe (ajouter ou supprimer des membres).
 - Les instructeur·rices se connectent sur le [lien de connexion Pitchou](https://pitchou.beta.gouv.fr/) obtiennent leur lien de connexion par email
-- L'équipe Pitchou accompagne le service insructeur dans l'ajout de premiers dossiers dans [Démarches Simplifiées](https://www.demarches-simplifiees.fr/commencer/derogation-especes-protegees)
+- L'équipe Pitchou accompagne le service insructeur dans l'ajout de premiers dossiers dans [Démarches Simplifiées](https://demarche.numerique.gouv.fr/commencer/derogation-especes-protegees)
 - Lorsque des dossiers ont été saisis par le service ou des pétitionnaires, les instructeur·rices se connectent sur Pitchou et peuvent accéder à leurs dossiers
 
 Nous porposons 3 niveaux d'embarquement progressif pour un service :

--- a/docs/projet-pitchou/technique/fichier-especes-ods.md
+++ b/docs/projet-pitchou/technique/fichier-especes-ods.md
@@ -6,7 +6,7 @@ Ce document décrit le format du fichier que l'on export sur la page <https://pi
 ## Contexte et description générale
 
 La plateforme Pitchou permet de gérer la procédure Demande de Dérogations Espèces Protégées (DDEP)
-Elle se repose notamment sur un [formulaire Démarches Simplifiées dédié](https://www.demarches-simplifiees.fr/commencer/derogation-especes-protegees)
+Elle se repose notamment sur un [formulaire Démarches Simplifiées dédié](https://demarche.numerique.gouv.fr/commencer/derogation-especes-protegees)
 
 La DDEP demande notamment au demandeur ou "pétitionnaire" de communiquer la liste des espèces protégées dont il demande une dérogation à déranger. Et pour chaque espèces, des données spécifiques (nombre d'individus, surface, activité, etc.)
 

--- a/scripts/commun/constantes.js
+++ b/scripts/commun/constantes.js
@@ -9,3 +9,5 @@ export const authorizedEmailDomains = new Set([
 ])
 
 export const mailtoJeNetrouvePasUneEspèce = "mailto:pitchou@beta.gouv.fr?subject=Rajouter%20une%20esp%C3%A8ce%20prot%C3%A9g%C3%A9e%20manquante&body=Bonjour%2C%0D%0A%0D%0AJe%20souhaite%20saisir%20une%20esp%C3%A8ce%20prot%C3%A9g%C3%A9es%20qui%20n'est%20pas%20list%C3%A9e%20dans%20l'outil%20Pitchou.%0D%0AFiche%20descriptive%20de%20l'esp%C3%A8ce%20%3A%0D%0A%0D%0ANom%20vernaculaire%20%3A%0D%0ANom%20latin%20%3A%0D%0ACD_NOM%20(identifiant%20TaxRef)%20%3A%0D%0ACommentaire%20%3A%0D%0A%0D%0AJe%20vous%20remercie%20de%20bien%20vouloir%20ajouter%20cette%20esp%C3%A8ce%0D%0A%0D%0AJe%20vous%20souhaite%20une%20belle%20journ%C3%A9e%20%E2%98%80%EF%B8%8F"
+
+export const urlDémarchesSimplifiées = "https://demarche.numerique.gouv.fr"

--- a/scripts/commun/constantes.js
+++ b/scripts/commun/constantes.js
@@ -10,4 +10,4 @@ export const authorizedEmailDomains = new Set([
 
 export const mailtoJeNetrouvePasUneEspèce = "mailto:pitchou@beta.gouv.fr?subject=Rajouter%20une%20esp%C3%A8ce%20prot%C3%A9g%C3%A9e%20manquante&body=Bonjour%2C%0D%0A%0D%0AJe%20souhaite%20saisir%20une%20esp%C3%A8ce%20prot%C3%A9g%C3%A9es%20qui%20n'est%20pas%20list%C3%A9e%20dans%20l'outil%20Pitchou.%0D%0AFiche%20descriptive%20de%20l'esp%C3%A8ce%20%3A%0D%0A%0D%0ANom%20vernaculaire%20%3A%0D%0ANom%20latin%20%3A%0D%0ACD_NOM%20(identifiant%20TaxRef)%20%3A%0D%0ACommentaire%20%3A%0D%0A%0D%0AJe%20vous%20remercie%20de%20bien%20vouloir%20ajouter%20cette%20esp%C3%A8ce%0D%0A%0D%0AJe%20vous%20souhaite%20une%20belle%20journ%C3%A9e%20%E2%98%80%EF%B8%8F"
 
-export const urlDémarchesSimplifiées = "https://demarche.numerique.gouv.fr"
+export const originDémarcheNumérique = "https://demarche.numerique.gouv.fr"

--- a/scripts/front-end/components/Dossier/DossierAvis.svelte
+++ b/scripts/front-end/components/Dossier/DossierAvis.svelte
@@ -1,4 +1,5 @@
 <script>
+	import { urlDémarchesSimplifiées } from '../../../commun/constantes.js'
 	import { formatDateAbsolue } from '../../affichageDossier.js'
 
     /** @import {DossierComplet} from '../../../types/API_Pitchou.js' */
@@ -52,10 +53,10 @@
     </section>
 
     <section>
-        <a class="fr-btn" target="_blank" href={`https://www.demarches-simplifiees.fr/procedures/${numéro_démarche}/dossiers/${numdos}/avis_new`}>
+        <a class="fr-btn" target="_blank" href={`${urlDémarchesSimplifiées}/procedures/${numéro_démarche}/dossiers/${numdos}/avis_new`}>
             Demander un avis
         </a>
-        <a class="fr-btn fr-btn--secondary" target="_blank" href={`https://www.demarches-simplifiees.fr/procedures/${numéro_démarche}/dossiers/${numdos}/avis`}>
+        <a class="fr-btn fr-btn--secondary" target="_blank" href={`${urlDémarchesSimplifiées}/procedures/${numéro_démarche}/dossiers/${numdos}/avis`}>
             Voir la page Avis sur Démarches Simplifiées
         </a>
     </section>

--- a/scripts/front-end/components/Dossier/DossierAvis.svelte
+++ b/scripts/front-end/components/Dossier/DossierAvis.svelte
@@ -1,5 +1,5 @@
 <script>
-	import { urlDémarchesSimplifiées } from '../../../commun/constantes.js'
+	import { originDémarcheNumérique } from '../../../commun/constantes.js'
 	import { formatDateAbsolue } from '../../affichageDossier.js'
 
     /** @import {DossierComplet} from '../../../types/API_Pitchou.js' */
@@ -53,10 +53,10 @@
     </section>
 
     <section>
-        <a class="fr-btn" target="_blank" href={`${urlDémarchesSimplifiées}/procedures/${numéro_démarche}/dossiers/${numdos}/avis_new`}>
+        <a class="fr-btn" target="_blank" href={`${originDémarcheNumérique}/procedures/${numéro_démarche}/dossiers/${numdos}/avis_new`}>
             Demander un avis
         </a>
-        <a class="fr-btn fr-btn--secondary" target="_blank" href={`${urlDémarchesSimplifiées}/procedures/${numéro_démarche}/dossiers/${numdos}/avis`}>
+        <a class="fr-btn fr-btn--secondary" target="_blank" href={`${originDémarcheNumérique}/procedures/${numéro_démarche}/dossiers/${numdos}/avis`}>
             Voir la page Avis sur Démarches Simplifiées
         </a>
     </section>

--- a/scripts/front-end/components/Dossier/DossierInstruction.svelte
+++ b/scripts/front-end/components/Dossier/DossierInstruction.svelte
@@ -7,6 +7,7 @@
     import {formatDateRelative, formatDateAbsolue, phases, prochaineActionAttenduePar} from '../../affichageDossier.js'
     import { modifierDossier } from '../../actions/dossier.js';
     import { instructeurLaisseDossier, instructeurSuitDossier } from '../../actions/suiviDossier.js';
+	import { urlDémarchesSimplifiées } from '../../../commun/constantes.js'
 
     /** @import Personne from '../../../types/database/public/Personne.js' */
     /** @import {DossierComplet} from '../../../types/API_Pitchou' */
@@ -208,7 +209,7 @@
         </div>
 
 
-        <a target="_blank" href={`https://www.demarches-simplifiees.fr/procedures/${numéro_démarche}/dossiers/${numdos}/annotations-privees`}>Annotations privées sur Démarches Simplifiées</a>
+        <a target="_blank" href={`${urlDémarchesSimplifiées}/procedures/${numéro_démarche}/dossiers/${numdos}/annotations-privees`}>Annotations privées sur Démarches Simplifiées</a>
 
     </section>
 

--- a/scripts/front-end/components/Dossier/DossierInstruction.svelte
+++ b/scripts/front-end/components/Dossier/DossierInstruction.svelte
@@ -7,7 +7,7 @@
     import {formatDateRelative, formatDateAbsolue, phases, prochaineActionAttenduePar} from '../../affichageDossier.js'
     import { modifierDossier } from '../../actions/dossier.js';
     import { instructeurLaisseDossier, instructeurSuitDossier } from '../../actions/suiviDossier.js';
-	import { urlDémarchesSimplifiées } from '../../../commun/constantes.js'
+	import { originDémarcheNumérique } from '../../../commun/constantes.js'
 
     /** @import Personne from '../../../types/database/public/Personne.js' */
     /** @import {DossierComplet} from '../../../types/API_Pitchou' */
@@ -209,7 +209,7 @@
         </div>
 
 
-        <a target="_blank" href={`${urlDémarchesSimplifiées}/procedures/${numéro_démarche}/dossiers/${numdos}/annotations-privees`}>Annotations privées sur Démarches Simplifiées</a>
+        <a target="_blank" href={`${originDémarcheNumérique}/procedures/${numéro_démarche}/dossiers/${numdos}/annotations-privees`}>Annotations privées sur Démarches Simplifiées</a>
 
     </section>
 

--- a/scripts/front-end/components/Dossier/DossierMessagerie.svelte
+++ b/scripts/front-end/components/Dossier/DossierMessagerie.svelte
@@ -1,4 +1,6 @@
 <script>
+	import { urlDémarchesSimplifiées } from '../../../commun/constantes.js'
+
     //@ts-check
 
     import {formatDateRelative, formatDateAbsolue} from '../../affichageDossier.js'
@@ -29,7 +31,7 @@
 <div class="row">
     <h2>Échanges avec le pétitionnaire</h2>
 
-    <a class="fr-btn fr-mb-w" target="_blank" href={`https://www.demarches-simplifiees.fr/procedures/${numéro_démarche}/dossiers/${numdos}/messagerie`}>
+    <a class="fr-btn fr-mb-w" target="_blank" href={`${urlDémarchesSimplifiées}/procedures/${numéro_démarche}/dossiers/${numdos}/messagerie`}>
         Répondre sur Démarches Simplifiées
     </a>
 </div>

--- a/scripts/front-end/components/Dossier/DossierMessagerie.svelte
+++ b/scripts/front-end/components/Dossier/DossierMessagerie.svelte
@@ -1,5 +1,5 @@
 <script>
-	import { urlDémarchesSimplifiées } from '../../../commun/constantes.js'
+	import { originDémarcheNumérique } from '../../../commun/constantes.js'
 
     //@ts-check
 
@@ -31,7 +31,7 @@
 <div class="row">
     <h2>Échanges avec le pétitionnaire</h2>
 
-    <a class="fr-btn fr-mb-w" target="_blank" href={`${urlDémarchesSimplifiées}/procedures/${numéro_démarche}/dossiers/${numdos}/messagerie`}>
+    <a class="fr-btn fr-mb-w" target="_blank" href={`${originDémarcheNumérique}/procedures/${numéro_démarche}/dossiers/${numdos}/messagerie`}>
         Répondre sur Démarches Simplifiées
     </a>
 </div>

--- a/scripts/front-end/components/Dossier/DossierProjet.svelte
+++ b/scripts/front-end/components/Dossier/DossierProjet.svelte
@@ -5,7 +5,7 @@
     import { formatDateRelative } from "../../affichageDossier.js";
     import { chargerActivitésMéthodesTransports } from "../../actions/activitésMéthodesTransports.js";
 	import Loader from "../Loader.svelte"
-	import { urlDémarchesSimplifiées } from "../../../commun/constantes.js"
+	import { originDémarcheNumérique } from "../../../commun/constantes.js"
 
     /** @import {DossierComplet} from '../../../types/API_Pitchou.ts' */
     /** @import {DescriptionMenacesEspèces} from '../../../types/especes.d.ts' */
@@ -256,7 +256,7 @@
         <a
             class="fr-btn fr-mb-1w"
             target="_blank"
-            href={`${urlDémarchesSimplifiées}/procedures/${numéro_démarche}/dossiers/${numdos}`}
+            href={`${originDémarcheNumérique}/procedures/${numéro_démarche}/dossiers/${numdos}`}
             >Dossier sur Démarches Simplifiées</a
         >
     </section>

--- a/scripts/front-end/components/Dossier/DossierProjet.svelte
+++ b/scripts/front-end/components/Dossier/DossierProjet.svelte
@@ -5,6 +5,7 @@
     import { formatDateRelative } from "../../affichageDossier.js";
     import { chargerActivitésMéthodesTransports } from "../../actions/activitésMéthodesTransports.js";
 	import Loader from "../Loader.svelte"
+	import { urlDémarchesSimplifiées } from "../../../commun/constantes.js"
 
     /** @import {DossierComplet} from '../../../types/API_Pitchou.ts' */
     /** @import {DescriptionMenacesEspèces} from '../../../types/especes.d.ts' */
@@ -255,7 +256,7 @@
         <a
             class="fr-btn fr-mb-1w"
             target="_blank"
-            href={`https://www.demarches-simplifiees.fr/procedures/${numéro_démarche}/dossiers/${numdos}`}
+            href={`${urlDémarchesSimplifiées}/procedures/${numéro_démarche}/dossiers/${numdos}`}
             >Dossier sur Démarches Simplifiées</a
         >
     </section>

--- a/scripts/front-end/components/screens/SuiviInstruction.svelte
+++ b/scripts/front-end/components/screens/SuiviInstruction.svelte
@@ -16,6 +16,7 @@
     import {retirerAccents} from '../../../commun/manipulationStrings.js'
     import {trierDossiersParOrdreAlphabétiqueColonne, trierDossiersParPhaseProchaineAction} from '../../triDossiers.js'
     import {instructeurLaisseDossier, instructeurSuitDossier} from '../../actions/suiviDossier.js';
+	import { urlDémarchesSimplifiées } from '../../../commun/constantes.js'
 
     /** @import {ComponentProps} from 'svelte' */
     /** @import {DossierDemarcheSimplifiee88444} from '../../../types/démarches-simplifiées/DémarcheSimplifiée88444.ts'*/
@@ -693,7 +694,7 @@
                 <div class="fr-mb-5w">
                     Il n'y a pas encore de dossiers associés à votre groupe instructeurs.
                     <br>
-                    Vous pouvez <a href="https://www.demarches-simplifiees.fr/commencer/derogation-especes-protegees">créer des dossiers sur démarches simplifiées</a>.
+                    Vous pouvez <a href={`${urlDémarchesSimplifiées}/commencer/derogation-especes-protegees`}>créer des dossiers sur démarches simplifiées</a>.
                     Et répondre un département correspondant à votre département ou région à la question
                     "Dans quel département se localise majoritairement votre projet ?"
                     <br>

--- a/scripts/front-end/components/screens/SuiviInstruction.svelte
+++ b/scripts/front-end/components/screens/SuiviInstruction.svelte
@@ -16,7 +16,7 @@
     import {retirerAccents} from '../../../commun/manipulationStrings.js'
     import {trierDossiersParOrdreAlphabétiqueColonne, trierDossiersParPhaseProchaineAction} from '../../triDossiers.js'
     import {instructeurLaisseDossier, instructeurSuitDossier} from '../../actions/suiviDossier.js';
-	import { urlDémarchesSimplifiées } from '../../../commun/constantes.js'
+	import { originDémarcheNumérique } from '../../../commun/constantes.js'
 
     /** @import {ComponentProps} from 'svelte' */
     /** @import {DossierDemarcheSimplifiee88444} from '../../../types/démarches-simplifiées/DémarcheSimplifiée88444.ts'*/
@@ -694,7 +694,7 @@
                 <div class="fr-mb-5w">
                     Il n'y a pas encore de dossiers associés à votre groupe instructeurs.
                     <br>
-                    Vous pouvez <a href={`${urlDémarchesSimplifiées}/commencer/derogation-especes-protegees`}>créer des dossiers sur démarches simplifiées</a>.
+                    Vous pouvez <a href={`${originDémarcheNumérique}/commencer/derogation-especes-protegees`}>créer des dossiers sur démarches simplifiées</a>.
                     Et répondre un département correspondant à votre département ou région à la question
                     "Dans quel département se localise majoritairement votre projet ?"
                     <br>


### PR DESCRIPTION
[Carte Trello](https://trello.com/c/XIEn3OIm/908-bug-liens-qui-redirigent-vers-d%C3%A9marches-simplifi%C3%A9es-doivent-contenir-le-nom-de-domaine-demarchesnumeriques-et-pas-d%C3%A9marches-simp)


Il reste des occurences de demarches-simplifiees que l'on peut traiter ultérieurement : https://github.com/betagouv/pitchou/issues/429