### PR TITLE
Fix bug impacts identiques après pré-remplissage par texte

### DIFF
--- a/scripts/front-end/components/SaisieEspèces/ModalePréremplirDepuisTexte.svelte
+++ b/scripts/front-end/components/SaisieEspèces/ModalePréremplirDepuisTexte.svelte
@@ -106,18 +106,18 @@
    function ajouterImpactPourChaqueClassification(impactPourChaqueOiseau, impactPourChaqueFauneNonOiseau, impactPourChaqueFlore) {
         espècesImpactéesPourPréremplir.forEach((espèceImpactée) => {
             if (espèceImpactée.espèce && espèceImpactée.espèce.classification === 'oiseau') {
-                espèceImpactée.impacts = [impactPourChaqueOiseau]
+                espèceImpactée.impacts = [{...impactPourChaqueOiseau }]
             } else if (espèceImpactée.espèce && espèceImpactée.espèce.classification === 'faune non-oiseau') {
-                espèceImpactée.impacts = [impactPourChaqueFauneNonOiseau]
+                espèceImpactée.impacts = [{...impactPourChaqueFauneNonOiseau}]
             } else if (espèceImpactée.espèce && espèceImpactée.espèce.classification === 'flore') {
-                espèceImpactée.impacts = [impactPourChaqueFlore]
+                espèceImpactée.impacts = [{...impactPourChaqueFlore}]
             }
         })
    }
 
     /**
      * Recheche "à l'arrache"
-     * 
+     *
      * @param {ParClassification<EspèceProtégée[]>} espècesProtégéesParClassification
      * @returns {Map<string, EspèceProtégée>}
      */
@@ -161,24 +161,24 @@
                     {#if écranAffiché === 'champTexte'}
                         <EcranChampTexte
                             bind:texteEspèces={texteEspèces}
-                            bind:espècesTrouvéesDansTexte={espècesTrouvéesDansTexte} 
-                            bind:écranAffiché={écranAffiché} 
+                            bind:espècesTrouvéesDansTexte={espècesTrouvéesDansTexte}
+                            bind:écranAffiché={écranAffiché}
                             espècesImpactéesPourPréremplir={espècesImpactéesPourPréremplir}
-                            {espècesProtégéesParClassification}  
-                            {idModalePréremplirDepuisTexte} 
-                            préremplirAvecCesEspècesImpacts={préremplirAvecCesEspècesImpacts} 
+                            {espècesProtégéesParClassification}
+                            {idModalePréremplirDepuisTexte}
+                            préremplirAvecCesEspècesImpacts={préremplirAvecCesEspècesImpacts}
                             supprimerEspèceImpactée={supprimerEspèceImpactéeImpactée}
                             />
                     {:else if écranAffiché === 'préciserImpact'}
                         <EcranPréciserImpact
-                            bind:écranAffiché={écranAffiché} 
-                            espècesImpactéesPourPréremplir={espècesImpactéesPourPréremplir} 
-                            supprimerEspèceImpactée={supprimerEspèceImpactéeImpactée} 
+                            bind:écranAffiché={écranAffiché}
+                            espècesImpactéesPourPréremplir={espècesImpactéesPourPréremplir}
+                            supprimerEspèceImpactée={supprimerEspèceImpactéeImpactée}
                             préremplirAvecCesEspècesImpacts={préremplirAvecCesEspècesImpacts}
-                            {ajouterImpactPourChaqueClassification} 
-                            {méthodesParClassificationEtreVivant} 
-                            {transportsParClassificationEtreVivant} 
-                            {activitesParClassificationEtreVivant} 
+                            {ajouterImpactPourChaqueClassification}
+                            {méthodesParClassificationEtreVivant}
+                            {transportsParClassificationEtreVivant}
+                            {activitesParClassificationEtreVivant}
                         />
                     {/if}
                 </div>
@@ -186,4 +186,3 @@
         </div>
     </div>
 </dialog>
-


### PR DESCRIPTION
Rapport du bug:

> Je crois que j’ai trouvé un bug !
> 1. J’ai pré-rempli depuis un texte (2 espèces, choucas des tours et fauvette pitchou)
> 2. Précisé l’impact dans la modale pour ces 2 espèces
> 3. Validé
> 4. Dans la page, j’ai voulu changer l’un des 2 impacts  Les 2 impacts restent identiques. Si je change l’impact de ma 1e espèce, celui de la 2e change aussi. Je m’attendrai à ce qu’ils soient indépendants.

Résolution du bug en créant un objet “impact” par espèce.