### PR TITLE
Créer la page Tous les dossiers - Partie 2

### DIFF
--- a/scripts/front-end/components/BadgePhase.svelte
+++ b/scripts/front-end/components/BadgePhase.svelte
@@ -1,0 +1,22 @@
+<script>
+    /** @import { DossierPhase } from '../../types/API_Pitchou.ts' */
+
+    /** @typedef Props
+     * @property {DossierPhase} phase
+    */
+
+    /** @type {Props}*/
+    let { phase } = $props()
+
+    /** @type {Map<DossierPhase, string>} */
+    const classParPhase = new Map([
+        ['Accompagnement amont', 'fr-badge--green-tilleul-verveine'],
+        ['Étude recevabilité DDEP', 'fr-badge--orange-terre-battue'],
+        ['Instruction', 'fr-badge--blue-ecume'],
+        ['Contrôle', 'fr-badge--pink-tuile'],
+        ['Classé sans suite', ''],
+        ['Obligations terminées', 'fr-badge--purple-glycine']
+    ])
+</script>
+
+<p class="fr-badge {classParPhase.get(phase)}">{phase}</p>

--- a/scripts/front-end/components/CarteDossier.svelte
+++ b/scripts/front-end/components/CarteDossier.svelte
@@ -1,9 +1,9 @@
 <script>
     /** @import { DossierRésumé } from "../../types/API_Pitchou" **/
-    /** @import {default as Dossier} from '../../types/database/public/Dossier.ts' */
+    /** @import { default as Dossier } from '../../types/database/public/Dossier.ts' */
 	import { formatDateAbsolue, formatLocalisation, formatPorteurDeProjet } from "../affichageDossier"
 	import BoutonModale from "./DSFR/BoutonModale.svelte"
-	import TagPhase from "./TagPhase.svelte"
+    import BadgePhase from "./BadgePhase.svelte"
 
     /**
      * @typedef Props
@@ -70,7 +70,7 @@
     <div class="contenu">
         <div class="première-ligne">
             <div>
-                <TagPhase phase={dossier.phase}  />
+                <BadgePhase phase={dossier.phase}  />
                 <div>
                     <span class="fr-icon-user-shared-2-line fr-icon--sm" aria-hidden="true"></span>
                     {dossier.prochaine_action_attendue_par || '(non renseignée)'}

--- a/scripts/front-end/components/CarteDossier.svelte
+++ b/scripts/front-end/components/CarteDossier.svelte
@@ -31,7 +31,7 @@
                 <span class="fr-icon-arrow-right-line" aria-hidden="true"></span>
             </a>
         </h2>
-        <div>
+        <div class="boutons-action">
             {#if dossier.commentaire_libre && dossier.commentaire_libre!==''}
                 {@const dsfrModaleId = `dsfr-modale-commentaire-${dossier.id}`}
                 <BoutonModale id={dsfrModaleId} >
@@ -142,6 +142,11 @@
         display: flex;
         flex-direction: column;
         gap: 1rem;
+
+        .boutons-action {
+            display: flex;
+            flex-direction: row;
+        }
 
         .première-ligne {
             display: flex;

--- a/scripts/front-end/components/TagPhase.svelte
+++ b/scripts/front-end/components/TagPhase.svelte
@@ -1,6 +1,8 @@
 <script>
-    //@ts-check
-  
+  /**
+   * @deprecated Utiliser BadgePhase à la place.
+   */
+
 	/** @import { MouseEventHandler } from 'svelte/elements' */
     /** @import { DossierPhase } from '../../types/API_Pitchou.ts' */
 	

--- a/scripts/front-end/components/screens/TousLesDossiers.svelte
+++ b/scripts/front-end/components/screens/TousLesDossiers.svelte
@@ -42,6 +42,7 @@
 
     let numéroDeLaPageSélectionnée = $state(1)
 
+    /** @type {string | undefined} */
     let texteÀChercher = $state()
 
     /** @type {HTMLDivElement | undefined} */
@@ -101,7 +102,10 @@
     /** @type {EventHandler<SubmitEvent, HTMLFormElement>}*/
     function soumettreTextePourRecherche (e) {
         e.preventDefault()
-        if (texteÀChercher) {
+        if (!texteÀChercher || texteÀChercher.trim() === '') {
+            tousLesFiltres.delete('texte')
+        }
+        if (texteÀChercher && texteÀChercher.trim() !== '') {
             tousLesFiltres.set('texte', créerFiltreTexte(texteÀChercher, dossiers))
             if (dossiersFiltrés.length > 0 && compteurDossiersElement) {
                 compteurDossiersElement.focus()
@@ -169,7 +173,7 @@
     }
 </script>
 
-<Squelette {email} {erreurs} title="Tous les dossiers">
+<Squelette {email} {erreurs} title="Tous les dddddossiers">
     <div class="en-tête">
         <div class="titre-et-barre-de-recherche">
             <h1>Tous les dossiers</h1>

--- a/scripts/front-end/components/screens/TousLesDossiers.svelte
+++ b/scripts/front-end/components/screens/TousLesDossiers.svelte
@@ -42,6 +42,11 @@
 
     let numéroDeLaPageSélectionnée = $state(1)
 
+    let texteÀChercher = $state()
+
+    /** @type {HTMLDivElement | undefined} */
+    let compteurDossiersElement = $state()
+
     const dossierIdsSuivisParInstructeurActuel = $derived(relationSuivis?.get(email))
 
     /** @typedef {() => void} SelectionneurPage */
@@ -83,13 +88,13 @@
     /** @type {EventHandler<SubmitEvent, HTMLFormElement>}*/
     function soumettreTextePourRecherche (e) {
         e.preventDefault()
-        const data = new FormData(e.currentTarget)
-        const texteÀChercher = data.get("texte-de-recherche")?.valueOf();
-
-        if (typeof texteÀChercher === 'string') {
+        if (texteÀChercher) {
             tousLesFiltres.set('texte', créerFiltreTexte(texteÀChercher, dossiers))
+            if (dossiersFiltrés.length > 0 && compteurDossiersElement) {
+                compteurDossiersElement.focus()
+            }
         }
-        e.currentTarget.reset()
+
     }
 
     /**
@@ -141,7 +146,7 @@
             <form onsubmit="{soumettreTextePourRecherche}">
                 <div class="fr-search-bar barre-de-recherche" role="search">
                     <label class="fr-label" for="search-input">Rechercher un dossier</label>
-                    <input name="texte-de-recherche" class="fr-input" aria-describedby="search-input-messages" placeholder="Rechercher" id="search-input" type="search">
+                    <input bind:value="{texteÀChercher}" name="texte-de-recherche" class="fr-input" aria-describedby="search-input-messages" placeholder="Rechercher" id="search-input" type="search">
                     <div class="fr-messages-group" id="search-input-messages" aria-live="polite">
                 </div>
                 <button title="Rechercher un dossier" type="submit" class="fr-btn">Rechercher un dossier</button>
@@ -160,7 +165,7 @@
                     Dossier sans instructeur·ice
                 </button>
             </div>
-            <div>
+            <div bind:this={compteurDossiersElement} tabindex="-1">
             <span class="fr-text--lead">{dossiersFiltrés.length}</span><span class="fr-text--lg">/{dossiers.length} dossiers</span>
             </div>
         </div>

--- a/scripts/front-end/components/screens/TousLesDossiers.svelte
+++ b/scripts/front-end/components/screens/TousLesDossiers.svelte
@@ -1,6 +1,7 @@
 <script>
     /** @import { DossierRésumé } from '../../../types/API_Pitchou.ts' */
 	/** @import { EventHandler } from "svelte/elements" */
+    /** @import { PitchouState } from '../../store.js' */
     /** @import {default as Dossier} from '../../../types/database/public/Dossier.ts' */
 	import { instructeurSuitDossier, instructeurLaisseDossier } from "../../actions/suiviDossier"
     import Squelette from "../Squelette.svelte"
@@ -14,12 +15,14 @@
     * @property {string} [email]
     * @property {DossierRésumé[]} dossiers
     * @property {Set<Dossier['id']>} [dossierIdsSuivisParInstructeurActuel]
+    * @property {PitchouState['erreurs']} [erreurs]
     */
     /** @type {Props} */
     let { 
             email = '',
             dossiers,
             dossierIdsSuivisParInstructeurActuel,
+            erreurs = new Set(),
         } = $props();
 
     const NOMBRE_DOSSIERS_PAR_PAGE = 10
@@ -104,7 +107,7 @@
     }
 </script>
 
-<Squelette {email} title="Tous les dossiers">
+<Squelette {email} {erreurs} title="Tous les dossiers">
     <div class="en-tête">
         <h1>Tous les dossiers</h1>
         <form onsubmit="{soumettreTextePourRecherche}">

--- a/scripts/front-end/components/screens/TousLesDossiers.svelte
+++ b/scripts/front-end/components/screens/TousLesDossiers.svelte
@@ -1,6 +1,6 @@
 <script>
     /** @import { DossierRésumé, DossierPhase } from '../../../types/API_Pitchou.ts' */
-	/** @import { EventHandler } from "svelte/elements" */
+	/** @import { ChangeEventHandler, EventHandler } from "svelte/elements" */
     /** @import { PitchouState } from '../../store.js' */
     /** @import {default as Dossier} from '../../../types/database/public/Dossier.ts' */
 	import { instructeurSuitDossier, instructeurLaisseDossier } from "../../actions/suiviDossier"
@@ -140,16 +140,15 @@
     }
 
     /**
-     * @param {DossierPhase} phase
+     * @type {ChangeEventHandler<HTMLSelectElement>}
      */
-    function sélectionnerPhase(phase) {
-        if (phaseSélectionnée === phase) {
-            // Désélectionner la phase
-            phaseSélectionnée = undefined
+    function sélectionnerPhase(e) {
+        e.preventDefault()
+        const phase =  e.currentTarget.value
+        if (phase === "") {
             tousLesFiltres.delete('phase')
         } else {
             // Sélectionner la phase
-            phaseSélectionnée = phase
             tousLesFiltres.set('phase', (dossier) => dossier.phase === phase)
         }
         // Réinitialiser la page à 1 quand on change le filtre
@@ -190,40 +189,16 @@
         <div class="filtres-et-compteur-dossiers">
             <div class="filtres">
                 <span class="fr-h4 texte-filtrer">Filtrer...</span>
-                <!--
-                    Ce composant avec la classe fr-translate est là pour qu'on aie un menu déroulant et le dsfr
-                    ne fournit pas de composant plus générique pour le moment
-                    Ce morceau sera à revisiter soit avec un composant fait par nous
-                    soit par une mise à jour du DSFR s'il contient un jour un composant qui nous convient
-                -->
-                <div class="fr-translate fr-nav">
-                    <div class="fr-nav__item">
-                        <button 
-                            aria-controls="filtre-par-phase" 
-                            aria-expanded="false"
-                            title="Choisir une phase" 
-                            type="button" 
-                            class="fr-btn fr-btn--tertiary"
-                        >
-                            {phaseSélectionnée ? `Phase : ${phaseSélectionnée}` : 'par phase'}
-                        </button>
-                        <div class="fr-collapse fr-translate__menu fr-menu" id="filtre-par-phase">
-                            <ul class="fr-menu__list">
-                                {#each toutesLesPhases as phase}
-                                    <li>
-                                        <button 
-                                            class="fr-translate__language fr-btn fr-btn--secondary fr-nav__link" type="button" data-fr-opened="false"
-                                            onclick={() => sélectionnerPhase(phase)}
-                                            aria-pressed={phaseSélectionnée === phase}
-                                        >
-                                            {phase}
-                                        </button>
-                                    </li>
-                                {/each}
-                            </ul>
-                        </div>
-                    </div>
+            <div class="fr-select-group div-select-phase">
+                <select aria-label="Phase" class="fr-select select-phase" aria-describedby="select-hint-messages" id="select-hint" name="select-hint" bind:value="{phaseSélectionnée}" onchange="{sélectionnerPhase}">
+                    <option value="" selected aria-label={'Sélectionner une phase'}>par phase</option>
+                    {#each toutesLesPhases as phase}
+                        <option value={phase}>{phase}</option>
+                    {/each}
+                </select>
+                <div class="fr-messages-group" id="select-hint-messages" aria-live="polite">
                 </div>
+            </div>
                 <button 
                     type="button"
                     class="fr-tag"
@@ -326,6 +301,15 @@
         min-width: 28rem;
         @media (max-width: 768px) {
             min-width: unset;
+        }
+    }
+
+    .div-select-phase {
+        margin-bottom: unset;
+        box-shadow: inset 0 0 0 1px var(--border-default-grey);
+        .select-phase {
+            background-color: unset;
+            box-shadow: unset;
         }
     }
 </style>

--- a/scripts/front-end/components/screens/TousLesDossiers.svelte
+++ b/scripts/front-end/components/screens/TousLesDossiers.svelte
@@ -2,7 +2,8 @@
     /** @import { DossierRésumé, DossierPhase } from '../../../types/API_Pitchou.ts' */
 	/** @import { ChangeEventHandler, EventHandler } from "svelte/elements" */
     /** @import { PitchouState } from '../../store.js' */
-    /** @import {default as Dossier} from '../../../types/database/public/Dossier.ts' */
+    /** @import { default as Dossier } from '../../../types/database/public/Dossier.ts' */
+	/** @import { ComponentProps } from "svelte" */
 	import { instructeurSuitDossier, instructeurLaisseDossier } from "../../actions/suiviDossier"
     import Squelette from "../Squelette.svelte"
     import CarteDossier from "../CarteDossier.svelte"
@@ -16,6 +17,7 @@
     * @property {DossierRésumé[]} dossiers
     * @property {PitchouState['relationSuivis']} [relationSuivis]
     * @property {PitchouState['erreurs']} [erreurs]
+    * @property {ComponentProps<typeof Squelette>['résultatsSynchronisationDS88444']} résultatsSynchronisationDS88444
     */
     /** @type {Props} */
     let { 
@@ -23,6 +25,8 @@
             dossiers,
             relationSuivis,
             erreurs = new Set(),
+            résultatsSynchronisationDS88444
+            
         } = $props();
 
     const NOMBRE_DOSSIERS_PAR_PAGE = 10
@@ -172,7 +176,7 @@
     }
 </script>
 
-<Squelette {email} {erreurs} title="Tous les dossiers">
+<Squelette {email} {erreurs} {résultatsSynchronisationDS88444} title="Tous les dossiers">
     <div class="en-tête">
         <div class="titre-et-barre-de-recherche">
             <h1>Tous les dossiers</h1>

--- a/scripts/front-end/components/screens/TousLesDossiers.svelte
+++ b/scripts/front-end/components/screens/TousLesDossiers.svelte
@@ -148,16 +148,21 @@
                 </div>
             </form>
         </div>
-        <div>
-            <button 
-                type="button"
-                class="fr-tag"
-                onclick={toggleFiltreSansInstructeurice}
-                aria-pressed={tousLesFiltres.has('sansInstructeurice')}
-            >
-                Dossier sans instructeur·ice
-            </button>
-            <span class="compteur-dossiers">{dossiersFiltrés.length}/{dossiers.length} dossiers</span>
+        <div class="filtres-et-compteur-dossiers">
+            <div class="filtres">
+                <span class="fr-h4 texte-filtrer">Filtrer...</span>
+                <button 
+                    type="button"
+                    class="fr-tag"
+                    onclick={toggleFiltreSansInstructeurice}
+                    aria-pressed={tousLesFiltres.has('sansInstructeurice')}
+                >
+                    Dossier sans instructeur·ice
+                </button>
+            </div>
+            <div>
+            <span class="fr-text--lead">{dossiersFiltrés.length}</span><span class="fr-text--lg">/{dossiers.length} dossiers</span>
+            </div>
         </div>
     </div>
     {#if dossiersAffichés.length >= 1}
@@ -201,7 +206,9 @@
     .en-tête {
         display: flex;
         flex-direction: column;
-        margin-bottom: 2rem;
+        margin-bottom: 1rem;
+        gap: 2rem;
+
         .titre-et-barre-de-recherche {
             display: flex;
             flex-direction: row;
@@ -212,15 +219,26 @@
                 justify-content: stretch;
             }
         }
+
+        .filtres-et-compteur-dossiers {
+            display: flex;
+            flex-direction: row;
+            justify-content: space-between;
+            align-items: center;
+
+            .filtres {
+                display: flex;
+                flex-direction: row;
+                gap: 1rem;
+                align-items: center;
+                .texte-filtrer {
+                    margin: 0;
+                }
+            }
+        }
     }
 
     .barre-de-recherche {
         min-width: 28rem;
-    }
-
-    .compteur-dossiers {
-        color: var(--text-mention-grey);
-        font-size: 0.875rem;
-        font-weight: 400;
     }
 </style>

--- a/scripts/front-end/components/screens/TousLesDossiers.svelte
+++ b/scripts/front-end/components/screens/TousLesDossiers.svelte
@@ -173,7 +173,7 @@
     }
 </script>
 
-<Squelette {email} {erreurs} title="Tous les dddddossiers">
+<Squelette {email} {erreurs} title="Tous les dossiers">
     <div class="en-tête">
         <div class="titre-et-barre-de-recherche">
             <h1>Tous les dossiers</h1>

--- a/scripts/front-end/components/screens/TousLesDossiers.svelte
+++ b/scripts/front-end/components/screens/TousLesDossiers.svelte
@@ -255,6 +255,7 @@
         display: flex;
         flex-direction: column;
         margin-bottom: 1rem;
+        margin-top: 2rem;
         gap: 2rem;
 
         .titre-et-barre-de-recherche {

--- a/scripts/front-end/routes/TousLesDossiers.js
+++ b/scripts/front-end/routes/TousLesDossiers.js
@@ -22,13 +22,14 @@ export default async () => {
         /** @type {DossierRésumé[]} */
         const dossiers = [...state.dossiersRésumés.values()]
         
-        const { email, erreurs } = mapStateToSqueletteProps(state);
+        const { email, erreurs, résultatsSynchronisationDS88444 } = mapStateToSqueletteProps(state);
         
         return {
             email,
             dossiers,
             relationSuivis: state.relationSuivis,
-            erreurs
+            erreurs,
+            résultatsSynchronisationDS88444
         };
     }
 

--- a/scripts/front-end/routes/TousLesDossiers.js
+++ b/scripts/front-end/routes/TousLesDossiers.js
@@ -23,12 +23,11 @@ export default async () => {
         const dossiers = [...state.dossiersRésumés.values()]
         
         const { email, erreurs } = mapStateToSqueletteProps(state);
-
-        const dossierIdsSuivisParInstructeurActuel = state?.relationSuivis?.get(email ?? '')
+        
         return {
             email,
             dossiers,
-            dossierIdsSuivisParInstructeurActuel,
+            relationSuivis: state.relationSuivis,
             erreurs
         };
     }

--- a/scripts/front-end/routes/TousLesDossiers.js
+++ b/scripts/front-end/routes/TousLesDossiers.js
@@ -5,37 +5,54 @@
 import { replaceComponent } from '../routeComponentLifeCycle.svelte.js'
 import { mapStateToSqueletteProps } from '../mapStateToSqueletteProps.js';
 import TousLesDossiers from '../components/screens/TousLesDossiers.svelte';
+import SqueletteContenuVide from '../components/SqueletteContenuVide.svelte';
 import { chargerDossiers } from '../actions/dossier.js';
+import store from '../store.js';
 
 
 export default async () => {
+    replaceComponent(SqueletteContenuVide, () => {})
+
+    /**
+     * 
+     * @param {PitchouState} state 
+     * @returns {ComponentProps<typeof TousLesDossiers>}
+     */
+    function mapStateToProps(state) {
+        /** @type {DossierRésumé[]} */
+        const dossiers = [...state.dossiersRésumés.values()]
+        
+        const { email, erreurs } = mapStateToSqueletteProps(state);
+
+        const dossierIdsSuivisParInstructeurActuel = state?.relationSuivis?.get(email ?? '')
+        return {
+            email,
+            dossiers,
+            dossierIdsSuivisParInstructeurActuel,
+            erreurs
+        };
+    }
+
     try {
-
         await chargerDossiers()
-
-        /**
-         * 
-         * @param {PitchouState} state 
-         * @returns {ComponentProps<typeof TousLesDossiers>}
-         */
-        function mapStateToProps(state) {
-            /** @type {DossierRésumé[]} */
-            const dossiers = [...state.dossiersRésumés.values()]
-            
-            const { email } = mapStateToSqueletteProps(state);
-
-
-
-            const dossierIdsSuivisParInstructeurActuel = state?.relationSuivis?.get(email ?? '')
-            return {
-                email,
-                dossiers,
-                dossierIdsSuivisParInstructeurActuel
-            };
-        }  
-
         replaceComponent(TousLesDossiers, mapStateToProps)
     } catch (error) {
         console.error('Erreur lors du chargement de la page Tous les dossiers :', error)
+        
+        const errorMessage = error instanceof Error ? error.message : String(error)
+        
+        if(errorMessage.includes('403')){
+            store.mutations.ajouterErreur({
+                message: `Erreur de connexion - Votre lien de connexion n'est plus valide, vous pouvez en recevoir par email ci-dessous`
+            })
+        }
+        else{
+            store.mutations.ajouterErreur({
+                message: `Erreur de chargement des dossiers - Il s'agit d'un problème technique. Vous pouvez en informer l'équipe Pitchou`
+            })
+        }
+
+        // Afficher le composant même en cas d'erreur pour que l'utilisateur voie le message d'erreur
+        replaceComponent(TousLesDossiers, mapStateToProps)
     }
 }


### PR DESCRIPTION
Dans cette PR : 

- [x] Faire en sorte que si y’a une erreur dans maroute Tous les dossiers, y’ait pas qu’un message dans la console mais informer l’utilisatrice comme pour la page d’accueil avec le composant Squelette
- [x] Rajouter le filtre "Dossier sans instructeurice"
- [x] Rajouter le nombre de dossiers
- [X] Laisser apparent le texte recherché dans la barre de recherche
- [X] Rajouter le filtre par phase (pour coller à l'UI + aux contraintes d'accessibilité : utiliser le composant Sélect du DSFR)
- [x] Créer le nouveau badge pour la phase
- [x] Rajouter la synchronisation DS
-  [x] Porter attention au responsive