### PR TITLE
fix initialisation du texte de l’autocomplete

### DIFF
--- a/scripts/front-end/components/SaisieEspèces/AutocompleteEspèces.svelte
+++ b/scripts/front-end/components/SaisieEspèces/AutocompleteEspèces.svelte
@@ -29,7 +29,7 @@
         espèceSélectionnée = $bindable(undefined)
     } = $props()
 
-    let text = $state('')
+    let text = $state(espèceSélectionnée ? espèceLabel(espèceSélectionnée) : '')
     let statusMessage = $state('')
 
     /** @type {number | null}*/


### PR DESCRIPTION
Si l’espèce est préremplie, initialise le texte de l’autocomplete avec le nom de l’espèce.