### PR TITLE
Retirer GITHUB_ACTION de la config de svelte-check-action et passage explicite à la version 1.5

### DIFF
--- a/.github/workflows/qualité-de-code.yml
+++ b/.github/workflows/qualité-de-code.yml
@@ -39,9 +39,7 @@ jobs:
 
         # Run the svelte check action
         - name: Svelte Check
-          uses: ghostdevv/svelte-check-action@v1
-          env:
-              GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          uses: ghostdevv/svelte-check-action@v1.5
           with:
             # filterChanges: false
             failOnError: true

--- a/scripts/front-end/components/Dossier/DossierGénérationDocuments.svelte
+++ b/scripts/front-end/components/Dossier/DossierGénérationDocuments.svelte
@@ -88,8 +88,6 @@
         }
 	}
 
-    erreurGénérationDocument = 5
-
 </script>
 
 <div class="row">

--- a/scripts/front-end/components/Dossier/DossierGénérationDocuments.svelte
+++ b/scripts/front-end/components/Dossier/DossierGénérationDocuments.svelte
@@ -88,6 +88,8 @@
         }
 	}
 
+    erreurGénérationDocument = 5
+
 </script>
 
 <div class="row">


### PR DESCRIPTION
Il y avait un warning qui disait que `GITHUB_ACTION` va être supprimé