### PR TITLE
Modifier la modale PJ pour les avis experts

### DIFF
--- a/scripts/front-end/components/Dossier/Avis/AvisExpert.svelte
+++ b/scripts/front-end/components/Dossier/Avis/AvisExpert.svelte
@@ -32,7 +32,15 @@
 
 <div class="carte-avis-expert">
     <div class="titre">
-        <h3 class="fr-h5">{avisExpert.expert ?? 'Expert'} - {avisExpert.avis ?? "Avis en attente"}</h3>
+        <h3 class="fr-h5">
+            {avisExpert.expert ?? 'Expert'}
+             - 
+        {#if (avisExpert.expert === 'Ministre' || avisExpert.expert === 'CNPN' || avisExpert.expert === 'CSRPN')}
+            {avisExpert.avis ?? "Avis en attente"}
+        {:else}
+            {avisExpert.avis_fichier_url ? 'Avis rendu' : 'Avis en attente'}
+        {/if}
+        </h3>
         {#if !avisExpertEnModification}
             <button class="fr-btn fr-btn--secondary fr-btn--sm fr-btn--icon-left fr-icon-pencil-line" type="button" onclick={() => avisExpertEnModification = true}>Modifier</button>
         {/if}

--- a/scripts/front-end/components/Dossier/Avis/FormulaireAvisExpert.svelte
+++ b/scripts/front-end/components/Dossier/Avis/FormulaireAvisExpert.svelte
@@ -31,10 +31,10 @@
     let chargementAjouterOuModifierAvisExpertP = $state(Promise.resolve());
 
     /** @type {string} */
-    let serviceOuPersonneExperte = $state(avisExpert?.expert && ['CSRPN', 'CNPN', 'Ministre', null].includes(avisExpert.expert) ? avisExpert.expert : 'Autre expert');
+    let serviceOuPersonneExperte = $state(avisExpert?.expert && ['CSRPN', 'CNPN', 'Ministre'].includes(avisExpert.expert) ? avisExpert.expert : 'Autre expert');
 
     /** @type {string | null} */
-    let autreExpertTexte = $state(avisExpert?.expert && ['CSRPN', 'CNPN', 'Ministre', null].includes(avisExpert.expert) ? null : avisExpert.expert ?? '')
+    let autreExpertTexte = $state(avisExpert?.expert && ['CSRPN', 'CNPN', 'Ministre'].includes(avisExpert.expert) ? null : avisExpert?.expert ?? '')
 
 
     /**

--- a/scripts/front-end/components/Dossier/Avis/FormulaireAvisExpert.svelte
+++ b/scripts/front-end/components/Dossier/Avis/FormulaireAvisExpert.svelte
@@ -173,31 +173,33 @@
                 <DateInput id={'input-champ-date-avis'} bind:date={avisExpert.date_avis}/>
             </div>
         </div>
-        <div class="fr-fieldset__element">
-            <div class="fr-input-group" id="champ-avis-group">
-                <p class="fr-label fr-mb-2w">Avis de l’expert</p>
+        {#if (avisExpert.expert === 'Ministre' || avisExpert.expert === 'CNPN' || avisExpert.expert === 'CSRPN')}
+            <div class="fr-fieldset__element">
+                <div class="fr-input-group" id="champ-avis-group">
+                    <p class="fr-label fr-mb-2w">Avis de l’expert</p>
 
-                {#each ['Avis favorable', 'Avis favorable tacite', 'Avis favorable sous condition', 'Avis défavorable'] as value}
-                    {@const id = `avis-${value.replace(/\s+/g, '-').toLowerCase()}`}
-                    <div class="fr-fieldset__element">
-                        <div class="fr-radio-group fr-ml-2w">
-                            <input
-                                type="radio"
-                                id={id}
-                                name="champ-avis"
-                                value={value}
-                                bind:group={avisExpert.avis}
-                            />
-                            <label class="fr-label" for={id}>
-                                {value}
-                            </label>
+                    {#each ['Avis favorable', 'Avis favorable tacite', 'Avis favorable sous condition', 'Avis défavorable'] as value}
+                        {@const id = `avis-${value.replace(/\s+/g, '-').toLowerCase()}`}
+                        <div class="fr-fieldset__element">
+                            <div class="fr-radio-group fr-ml-2w">
+                                <input
+                                    type="radio"
+                                    id={id}
+                                    name="champ-avis"
+                                    value={value}
+                                    bind:group={avisExpert.avis}
+                                />
+                                <label class="fr-label" for={id}>
+                                    {value}
+                                </label>
+                            </div>
                         </div>
-                    </div>
-                {/each}
+                    {/each}
 
-                <div class="fr-messages-group" id="champ-avis-group-messages" aria-live="polite"></div>
+                    <div class="fr-messages-group" id="champ-avis-group-messages" aria-live="polite"></div>
+                </div>
             </div>
-        </div>
+        {/if}
         <div class="fr-messages-group" id="formulaire-ajouter-avis-expert-fieldset-messages" aria-live="polite">
             {#if messageErreur}
                 <div class="fr-alert fr-alert--error fr-alert--sm fr-mb-2w">

--- a/scripts/front-end/components/Dossier/Avis/FormulaireAvisExpert.svelte
+++ b/scripts/front-end/components/Dossier/Avis/FormulaireAvisExpert.svelte
@@ -173,7 +173,7 @@
                 <DateInput id={'input-champ-date-avis'} bind:date={avisExpert.date_avis}/>
             </div>
         </div>
-        {#if (avisExpert.expert === 'Ministre' || avisExpert.expert === 'CNPN' || avisExpert.expert === 'CSRPN')}
+        {#if (serviceOuPersonneExperte === 'Ministre' || serviceOuPersonneExperte === 'CNPN' || serviceOuPersonneExperte === 'CSRPN')}
             <div class="fr-fieldset__element">
                 <div class="fr-input-group" id="champ-avis-group">
                     <p class="fr-label fr-mb-2w">Avis de l’expert</p>

--- a/scripts/front-end/components/Dossier/Avis/FormulaireAvisExpert.svelte
+++ b/scripts/front-end/components/Dossier/Avis/FormulaireAvisExpert.svelte
@@ -30,11 +30,11 @@
     /** @type {Promise<void>} */
     let chargementAjouterOuModifierAvisExpertP = $state(Promise.resolve());
 
-    /** @type {string | null} */
-    let serviceOuPersonneExperte = $state(['CSRPN', 'CNPN', 'Ministre', null].includes(avisExpert.expert ?? null) ? avisExpert.expert ?? null : 'Autre expert')
+    /** @type {string} */
+    let serviceOuPersonneExperte = $state(avisExpert?.expert && ['CSRPN', 'CNPN', 'Ministre', null].includes(avisExpert.expert) ? avisExpert.expert : 'Autre expert');
 
     /** @type {string | null} */
-    let autreExpertTexte = $state(avisExpert.expert !== undefined && ['CSRPN', 'CNPN', 'Ministre', null].includes(avisExpert.expert) ? null : avisExpert.expert ?? null)
+    let autreExpertTexte = $state(avisExpert?.expert && ['CSRPN', 'CNPN', 'Ministre', null].includes(avisExpert.expert) ? null : avisExpert.expert ?? '')
 
 
     /**

--- a/scripts/front-end/components/Dossier/ModaleAjouterPièceJointe.svelte
+++ b/scripts/front-end/components/Dossier/ModaleAjouterPièceJointe.svelte
@@ -21,6 +21,8 @@
 
     const idTitreH2 = `${id}-title`
 
+    const OPTIONS_SERVICE_EXPERT = ['CSRPN', 'CNPN', 'Ministre', 'Autre expert'];
+
     /** @type {FileList | undefined} */
     let fileListPièceJointe = $state()
 
@@ -240,7 +242,7 @@
                                     <div class="fr-fieldset fr-mt-3w" id="champ-service-expert-group">
                                         <legend class="fr-fieldset__legend--regular fr-fieldset__legend" id="champ-service-expert-group"> Service ou personne experte </legend>
                                         <div class="conteneur-boutons-radios">
-                                            {#each ['CSRPN', 'CNPN', 'Ministre', 'Autre expert'] as service}
+                                            {#each OPTIONS_SERVICE_EXPERT as service}
                                                 {@const idRadio = `service-expert-${service.replace(/\s+/g, '-').toLowerCase()}-${id}`}
                                                 <div class="fr-fieldset__element">
                                                     <div class="fr-radio-group">
@@ -325,7 +327,7 @@
                                         <div class="fr-fieldset fr-mt-3w" id="champ-service-expert-group">
                                             <legend class="fr-fieldset__legend--regular fr-fieldset__legend" id="champ-service-expert-group"> Service ou personne experte </legend>
                                             <div class="conteneur-boutons-radios">
-                                                {#each ['CSRPN', 'CNPN', 'Autre expert'] as service}
+                                                {#each OPTIONS_SERVICE_EXPERT as service}
                                                     {@const idRadio = `service-expert-${service.replace(/\s+/g, '-').toLowerCase()}-${id}`}
                                                     <div class="fr-fieldset__element">
                                                         <div class="fr-radio-group">

--- a/scripts/front-end/components/Dossier/ModaleAjouterPièceJointe.svelte
+++ b/scripts/front-end/components/Dossier/ModaleAjouterPièceJointe.svelte
@@ -79,7 +79,7 @@
         typePièceJointe === 'Avis expert' 
         && avisExpertSélectionné !== null
         && (avisExpertSélectionné === 'nouvel-avis-expert' ? serviceOuPersonneExperte !== null : true)
-        // Les experts Ministre, CNPN et CSRPN sont nécessiarement liés à un Avis (conforme, non conforme...)
+        // Les experts Ministre, CNPN et CSRPN sont nécessairement liés à un Avis (conforme, non conforme...)
         && ((serviceOuPersonneExperte === 'Ministre' || serviceOuPersonneExperte === 'CNPN' || serviceOuPersonneExperte === 'CSRPN') ? avis !== null : true))
     
     let formulaireValide = $derived(

--- a/scripts/front-end/components/Dossier/ModaleAjouterPièceJointe.svelte
+++ b/scripts/front-end/components/Dossier/ModaleAjouterPièceJointe.svelte
@@ -360,7 +360,7 @@
                                             </div>
                                         {/if}
                                     {/if}
-                                    {#if (serviceOuPersonneExperte !== 'Autre expert' && serviceOuPersonneExperte !== null)}
+                                    {#if (serviceOuPersonneExperte === 'Ministre' || serviceOuPersonneExperte === 'CNPN' || serviceOuPersonneExperte === 'CSRPN')}
                                         <div class="fr-fieldset fr-mt-3w" id="champ-avis-expert-group">
                                             <legend class="fr-fieldset__legend--regular fr-fieldset__legend" id="champ-avis-expert-group"> Avis de l'expert </legend>
                                             <div class="">

--- a/scripts/front-end/components/Dossier/ModaleAjouterPièceJointe.svelte
+++ b/scripts/front-end/components/Dossier/ModaleAjouterPièceJointe.svelte
@@ -249,6 +249,7 @@
                                                 <div class="fr-fieldset__element">
                                                     <div class="fr-radio-group">
                                                         <input
+                                                            required
                                                             type="radio"
                                                             id={idRadio}
                                                             name="service-expert-{id}"
@@ -334,6 +335,7 @@
                                                     <div class="fr-fieldset__element">
                                                         <div class="fr-radio-group">
                                                             <input
+                                                                required
                                                                 type="radio"
                                                                 id={idRadio}
                                                                 name="service-expert-{id}"
@@ -371,6 +373,7 @@
                                                     <div class="fr-fieldset__element">
                                                         <div class="fr-radio-group">
                                                             <input
+                                                                required
                                                                 type="radio"
                                                                 id={idRadio}
                                                                 name="avis-expert-{id}"

--- a/scripts/front-end/components/Dossier/ModaleAjouterPièceJointe.svelte
+++ b/scripts/front-end/components/Dossier/ModaleAjouterPièceJointe.svelte
@@ -189,14 +189,22 @@
                             Ajouter une pièce jointe
                         </h2>
                         <form onsubmit={(e) => { e.preventDefault(); ajouterPièceJointe(); }}>
+                            <p class="fr-text--sm fr-mb-2w">
+                                <span class="obligatoire-asterisque">*</span>
+                                Champs obligatoires
+                            </p>
                             <div class="fr-fieldset fr-mt-3w" id="champ-type-piece-jointe-group">
-                                <legend class="fr-fieldset__legend--regular fr-fieldset__legend" id="champ-type-piece-jointe-group"> Type de pièce jointe </legend>
+                                <legend class="fr-fieldset__legend--regular fr-fieldset__legend" id="champ-type-piece-jointe-group"> 
+                                    Type de pièce jointe
+                                    <span class="obligatoire-asterisque">*</span>
+                                </legend>
                                     <div class="conteneur-boutons-radios">
                                         {#each ['Saisine expert', 'Avis expert'] as type}
                                             {@const idRadio = `type-piece-jointe-${type.replace(/\s+/g, '-').toLowerCase()}-${id}`}
                                             <div class="fr-fieldset__element">
                                                 <div class="fr-radio-group">
                                                     <input
+                                                        required
                                                         type="radio"
                                                         id={idRadio}
                                                         name="type-piece-jointe-{id}"
@@ -220,11 +228,13 @@
                                         {:else}
                                             Choisir un ou plusieurs fichiers
                                         {/if}
+                                        <span class="obligatoire-asterisque">*</span>
                                         <span class="fr-hint-text">
                                             Indication : taille maximale&nbsp;: 500 Mo. Formats supportés&nbsp;: xls, ods, pdf, odt. Plusieurs fichiers possibles.
                                         </span>
                                     </label>
-                                    <input 
+                                    <input
+                                        required
                                         bind:this={fileInput}
                                         accept=".xls,.ods,.pdf,.odt" 
                                         bind:files={fileListPièceJointe} 
@@ -242,7 +252,10 @@
                             {#if fileListPièceJointe && fileListPièceJointe.length > 0}
                                 {#if typePièceJointe === 'Saisine expert'}
                                     <div class="fr-fieldset fr-mt-3w" id="champ-service-expert-group">
-                                        <legend class="fr-fieldset__legend--regular fr-fieldset__legend" id="champ-service-expert-group"> Service ou personne experte (Champ obligatoire)</legend>
+                                        <legend class="fr-fieldset__legend--regular fr-fieldset__legend" id="champ-service-expert-group">
+                                            Service ou personne experte
+                                            <span class="obligatoire-asterisque">*</span>
+                                        </legend>
                                         <div class="conteneur-boutons-radios">
                                             {#each OPTIONS_SERVICE_EXPERT as service}
                                                 {@const idRadio = `service-expert-${service.replace(/\s+/g, '-').toLowerCase()}-${id}`}
@@ -328,7 +341,10 @@
 
                                     {#if avisExpertSélectionné === 'nouvel-avis-expert'}
                                         <div class="fr-fieldset fr-mt-3w" id="champ-service-expert-group">
-                                            <legend class="fr-fieldset__legend--regular fr-fieldset__legend" id="champ-service-expert-group"> Service ou personne experte (Champ obligatoire)</legend>
+                                            <legend class="fr-fieldset__legend--regular fr-fieldset__legend" id="champ-service-expert-group">
+                                                Service ou personne experte
+                                                <span class="obligatoire-asterisque">*</span>
+                                            </legend>
                                             <div class="conteneur-boutons-radios">
                                                 {#each OPTIONS_SERVICE_EXPERT as service}
                                                     {@const idRadio = `service-expert-${service.replace(/\s+/g, '-').toLowerCase()}-${id}`}
@@ -366,7 +382,10 @@
                                     {/if}
                                     {#if (serviceOuPersonneExperte === 'Ministre' || serviceOuPersonneExperte === 'CNPN' || serviceOuPersonneExperte === 'CSRPN')}
                                         <div class="fr-fieldset fr-mt-3w" id="champ-avis-expert-group">
-                                            <legend class="fr-fieldset__legend--regular fr-fieldset__legend" id="champ-avis-expert-group"> Avis de l'expert (Champ obligatoire)</legend>
+                                            <legend class="fr-fieldset__legend--regular fr-fieldset__legend" id="champ-avis-expert-group">
+                                                Avis de l'expert
+                                                <span class="obligatoire-asterisque">*</span>
+                                            </legend>
                                             <div class="">
                                                 {#each ['Avis favorable', 'Avis favorable sous condition', 'Avis défavorable'] as avisOption}
                                                     {@const idRadio = `avis-expert-${avisOption.replace(/\s+/g, '-').toLowerCase()}-${id}`}
@@ -445,5 +464,11 @@
         display: flex;
         flex-direction: column;
         gap: 0.5rem;
+    }
+
+    .obligatoire-asterisque {
+        color: var(--text-title-blue-france, #000091);
+        margin-left: 0.25rem;
+        font-weight: bold;
     }
 </style>

--- a/scripts/front-end/components/Dossier/ModaleAjouterPièceJointe.svelte
+++ b/scripts/front-end/components/Dossier/ModaleAjouterPièceJointe.svelte
@@ -358,28 +358,30 @@
                                             </div>
                                         {/if}
                                     {/if}
-                                    <div class="fr-fieldset fr-mt-3w" id="champ-avis-expert-group">
-                                        <legend class="fr-fieldset__legend--regular fr-fieldset__legend" id="champ-avis-expert-group"> Avis de l'expert </legend>
-                                        <div class="">
-                                            {#each ['Avis favorable', 'Avis favorable sous condition', 'Avis défavorable'] as avisOption}
-                                                {@const idRadio = `avis-expert-${avisOption.replace(/\s+/g, '-').toLowerCase()}-${id}`}
-                                                <div class="fr-fieldset__element">
-                                                    <div class="fr-radio-group">
-                                                        <input
-                                                            type="radio"
-                                                            id={idRadio}
-                                                            name="avis-expert-{id}"
-                                                            value={avisOption}
-                                                            bind:group={avis}
-                                                        />
-                                                        <label class="fr-label" for={idRadio}>
-                                                            {avisOption}
-                                                        </label>
+                                    {#if (serviceOuPersonneExperte !== 'Autre expert' && serviceOuPersonneExperte !== null)}
+                                        <div class="fr-fieldset fr-mt-3w" id="champ-avis-expert-group">
+                                            <legend class="fr-fieldset__legend--regular fr-fieldset__legend" id="champ-avis-expert-group"> Avis de l'expert </legend>
+                                            <div class="">
+                                                {#each ['Avis favorable', 'Avis favorable sous condition', 'Avis défavorable'] as avisOption}
+                                                    {@const idRadio = `avis-expert-${avisOption.replace(/\s+/g, '-').toLowerCase()}-${id}`}
+                                                    <div class="fr-fieldset__element">
+                                                        <div class="fr-radio-group">
+                                                            <input
+                                                                type="radio"
+                                                                id={idRadio}
+                                                                name="avis-expert-{id}"
+                                                                value={avisOption}
+                                                                bind:group={avis}
+                                                            />
+                                                            <label class="fr-label" for={idRadio}>
+                                                                {avisOption}
+                                                            </label>
+                                                        </div>
                                                     </div>
-                                                </div>
-                                            {/each}
+                                                {/each}
+                                            </div>
                                         </div>
-                                    </div>
+                                    {/if}
                                     <div class="fr-mt-3w">
                                         <label class="fr-input-group fr-label" for="modale-date-avis-{id}">Date de l'avis</label>
                                         <DateInput id={`modale-date-avis-${id}`} bind:date={dateAvis} />

--- a/scripts/front-end/components/Dossier/ModaleAjouterPièceJointe.svelte
+++ b/scripts/front-end/components/Dossier/ModaleAjouterPièceJointe.svelte
@@ -74,18 +74,20 @@
         }
     })
 
+    let formulaireValidePourSaisineExpert = $derived(typePièceJointe === 'Saisine expert' && serviceOuPersonneExperte !== null)
+    let formulaireValidePourAvisExpert = $derived(
+        typePièceJointe === 'Avis expert' 
+        && avisExpertSélectionné !== null
+        && (avisExpertSélectionné === 'nouvel-avis-expert' ? serviceOuPersonneExperte !== null : true)
+        // Les experts Ministre, CNPN et CSRPN sont nécessiarement liés à un Avis (conforme, non conforme...)
+        && ((serviceOuPersonneExperte === 'Ministre' || serviceOuPersonneExperte === 'CNPN' || serviceOuPersonneExperte === 'CSRPN') ? avis !== null : true))
+    
     let formulaireValide = $derived(
         fileListPièceJointe && fileListPièceJointe.length > 0 && 
         typePièceJointe !== null && typePièceJointe !== undefined &&
         (
-            (typePièceJointe === 'Saisine expert' && serviceOuPersonneExperte !== null && 
-                // @ts-ignore ts ne comprend pas que autreExpertTexte peut être de type string
-                (serviceOuPersonneExperte !== 'Autre expert' || (autreExpertTexte && autreExpertTexte.trim() !== ''))) ||
-            (typePièceJointe === 'Avis expert' && avisExpertSélectionné !== null && avis !== null && 
-                (avisExpertSélectionné === 'nouvel-avis-expert' 
-                    // @ts-ignore ts ne comprend pas que autreExpertTexte peut être de type string
-                    ? serviceOuPersonneExperte !== null && (serviceOuPersonneExperte !== 'Autre expert' || (autreExpertTexte !== null && autreExpertTexte.trim() !== ''))
-                    : true))
+            formulaireValidePourSaisineExpert ||
+            formulaireValidePourAvisExpert
         )
     )
 
@@ -240,7 +242,7 @@
                             {#if fileListPièceJointe && fileListPièceJointe.length > 0}
                                 {#if typePièceJointe === 'Saisine expert'}
                                     <div class="fr-fieldset fr-mt-3w" id="champ-service-expert-group">
-                                        <legend class="fr-fieldset__legend--regular fr-fieldset__legend" id="champ-service-expert-group"> Service ou personne experte </legend>
+                                        <legend class="fr-fieldset__legend--regular fr-fieldset__legend" id="champ-service-expert-group"> Service ou personne experte (Champ obligatoire)</legend>
                                         <div class="conteneur-boutons-radios">
                                             {#each OPTIONS_SERVICE_EXPERT as service}
                                                 {@const idRadio = `service-expert-${service.replace(/\s+/g, '-').toLowerCase()}-${id}`}
@@ -325,7 +327,7 @@
 
                                     {#if avisExpertSélectionné === 'nouvel-avis-expert'}
                                         <div class="fr-fieldset fr-mt-3w" id="champ-service-expert-group">
-                                            <legend class="fr-fieldset__legend--regular fr-fieldset__legend" id="champ-service-expert-group"> Service ou personne experte </legend>
+                                            <legend class="fr-fieldset__legend--regular fr-fieldset__legend" id="champ-service-expert-group"> Service ou personne experte (Champ obligatoire)</legend>
                                             <div class="conteneur-boutons-radios">
                                                 {#each OPTIONS_SERVICE_EXPERT as service}
                                                     {@const idRadio = `service-expert-${service.replace(/\s+/g, '-').toLowerCase()}-${id}`}
@@ -362,7 +364,7 @@
                                     {/if}
                                     {#if (serviceOuPersonneExperte === 'Ministre' || serviceOuPersonneExperte === 'CNPN' || serviceOuPersonneExperte === 'CSRPN')}
                                         <div class="fr-fieldset fr-mt-3w" id="champ-avis-expert-group">
-                                            <legend class="fr-fieldset__legend--regular fr-fieldset__legend" id="champ-avis-expert-group"> Avis de l'expert </legend>
+                                            <legend class="fr-fieldset__legend--regular fr-fieldset__legend" id="champ-avis-expert-group"> Avis de l'expert (Champ obligatoire)</legend>
                                             <div class="">
                                                 {#each ['Avis favorable', 'Avis favorable sous condition', 'Avis défavorable'] as avisOption}
                                                     {@const idRadio = `avis-expert-${avisOption.replace(/\s+/g, '-').toLowerCase()}-${id}`}


### PR DESCRIPTION
Quand on sélectionne “Autre expert”, alors on ne veut pas avoir à remplir la partie “Avis de l'expert : Avis favorable / Avis favorable sous condition / Avis défavorable”