### PR TITLE
fix: nom de fichiers de pièces jointes avec caractères unicode

### DIFF
--- a/scripts/server/main.js
+++ b/scripts/server/main.js
@@ -382,8 +382,15 @@ async function téléchargementFichierRouteHandler(request, reply) {
     return
   }
   else{
+    const nomDuFichierAscii = fichier.nom.normalize("NFD")
+      .replace(/[\u0300-\u036f]/g, "") // Supprime les diacritiques
+      .replace(/[^\x00-\x7F]/g, "") // Supprime les caractères non ascii
+
+    // On met les deux headers pour maximiser la compatibilité entre navigateurs
+    // Voir: <https://developer.mozilla.org/fr/docs/Web/HTTP/Reference/Headers/Content-Disposition>
     reply
-      .header('content-disposition', `attachment; filename="${fichier.nom}"`)
+      .header('content-disposition', `attachment; filename="${nomDuFichierAscii}"`)
+      .header('content-disposition', `attachment; filename*=UTF-8''${encodeURI(fichier.nom)}`)
       .header('content-type', fichier.media_type)
       .send(fichier.contenu)
   }
@@ -497,7 +504,6 @@ fastify.post('/prescriptions-et-contrôles', function(request, reply) {
 })
 
 
-
 fastify.delete('/prescription/:prescriptionId', async function(request, reply) {
   //@ts-ignore
   if(!request.params.prescriptionId){
@@ -553,11 +559,11 @@ fastify.post('/avis-expert', {
     body: {
       type: 'object',
       required: ['dossier'],
-      properties: 
+      properties:
         {
           body : {
             type: 'object',
-                  properties: 
+                  properties:
                     {
                       dossier: {
                         type: 'string',
@@ -597,7 +603,7 @@ fastify.post('/avis-expert', {
   const id = body.id ? body.id.value : undefined;
   const expert = body.expert ? body.expert.value : undefined
   const avis = body.avis ? body.avis.value : undefined
-  
+
   const date_saisine = body['date_saisine'] ? new Date(body['date_saisine'].value) : undefined
   const date_avis = body['date_avis'] ? new Date(body['date_avis'].value) : undefined
 
@@ -622,7 +628,7 @@ fastify.post('/avis-expert', {
     /** @type {any} */
     const blobFichierAvis = body.blobFichierAvis
     fichierAvis = {nom: blobFichierAvis.filename, media_type: blobFichierAvis.mimetype, contenu: blobFichierAvisContenu}
-  } 
+  }
 
   if (fichierAvis || fichierSaisine) {
     return ajouterOuModifierAvisExpertAvecFichiers(avisExpert, fichierSaisine, fichierAvis)


### PR DESCRIPTION
Certaines pièces jointe contiennent des caractères Unicode qui génèrent une erreur du serveur lorsqu’on essaie de les télécharger.

Exemple de nom de fichier problématique: `Projet parc photovoltaïque –  dossier.pdf`. 

La présence du tiret semi cadratin engendre cette erreur:

```
[13:41:03 UTC] ERROR: [req-3] GET /avis-expert/fichier/a033f4b9-8cea-4845-8815-8dae67fabc58 500 Invalid character in header content ["content-disposition"]
```