### PR TITLE
Créer les fichiers résultat AARRI dans un sous-dossier de 'build'

### DIFF
--- a/outils/aarri/constants.js
+++ b/outils/aarri/constants.js
@@ -1,0 +1,3 @@
+import {join} from 'node:path'
+
+export const fichiersAARRIDirPath = join(import.meta.dirname, '..', '..', 'build', 'tmp-aarri')

--- a/outils/aarri/donnees-pour-personne.js
+++ b/outils/aarri/donnees-pour-personne.js
@@ -6,6 +6,8 @@ import { formatDateAbsolue } from '../../scripts/front-end/affichageDossier.js';
 import { closeDatabaseConnection } from '../../scripts/server/database.js';
 import { writeFile, mkdir } from 'node:fs/promises'
 
+import {fichiersAARRIDirPath} from './constants.js'
+
 const args = parseArgs(process.argv)
 
 let origin = 'https://pitchou.beta.gouv.fr'
@@ -114,14 +116,14 @@ const content = new Map([
 /** @type {ArrayBuffer} */
 const ods = await createOdsFile(content)
 const nomDeFichierODS = email + '-' + Math.random().toString(36).slice(2) + '.ods'
-const cheminDuFichierODS = `/tmp/pitchou/${nomDeFichierODS}`
+const cheminDuFichierODS = `${fichiersAARRIDirPath}/${nomDeFichierODS}`
 
 try {
     console.log('📝 Création du fichier ODS avec les résultats...')
-    await mkdir('/tmp/pitchou', { recursive: true })
+    await mkdir(fichiersAARRIDirPath, {recursive: true})
     await writeFile(cheminDuFichierODS, Buffer.from(ods))
-    console.log(`✅ Le fichier a bien été écrit dans ${cheminDuFichierODS}.`)
-    const lienTéléchargementFichier = `${origin}/tmp/${nomDeFichierODS}`
+    console.log(`✅ Le fichier a bien été écrit dans ${cheminDuFichierODS}`)
+    const lienTéléchargementFichier = `${origin}/build/tmp-aarri/${nomDeFichierODS}`
     console.log(`Télécharger le fichier en cliquant ici : ${lienTéléchargementFichier}`)
 
   } catch (err) {

--- a/scripts/server/main.js
+++ b/scripts/server/main.js
@@ -96,15 +96,12 @@ await fastify.register(fastifyCompress)
 fastify.register(fastatic, {
   root: path.resolve(import.meta.dirname, '..', '..'),
   extensions: ['html'],
+  // certains fichiers ont vocation à rester secrets
+  // ils sont protégés par une partie aléatoire dans leurs noms
+  // cette option permet de ne pas dévoiler leur nom
+  list: false
 })
 
-// Servir les dossiers statiques contenant des fichiers que l'on souhaite télécharger.
-fastify.register(fastatic, {
-  root: '/tmp/pitchou',
-  prefix: '/tmp',
-  // cf https://github.com/fastify/fastify-static?tab=readme-ov-file#multiple-prefixed-roots
-  decorateReply: false,
-})
 
 fastify.register(fastifyMultipart, {
   attachFieldsToBody: true,


### PR DESCRIPTION
Suite à qui https://github.com/betagouv/pitchou/pull/516 a échoué parce qu'apparemment les one-off de scalingo ne partagent pas leur /tmp avec l'application déployée

On tente dans un sous-dossier de 'build'