### PR TITLE
[Espèces Ministérielles/CNPN] Dans l'interface Pitchou, rendre visible l'information Espèce Ministérielle ou CNPN

### DIFF
--- a/docs/instruction/document-types/creation.md
+++ b/docs/instruction/document-types/creation.md
@@ -304,7 +304,7 @@ Pour la liste {liste_espèces_par_impact}, chaque élément de la liste contient
                         <tr>
                             <th scope="row"> <code>{liste_espèces}</code></th>
                             <td> liste</td>
-                            <td> Liste les espèces concernées par un impact. Chaque élément de la liste contient les propriétés : <code>{liste_impacts_quantifiés}</code>, <code>{nomScientifique}</code> et <code>{nomVernaculaire}</code></td>
+                            <td> Liste les espèces concernées par un impact. Chaque élément de la liste contient les propriétés : <code>{liste_impacts_quantifiés}</code>, <code>{nomScientifique}</code>, <code>{nomVernaculaire}</code>, <code>{estMinistérielle}</code> et <code>{estCNPN}</code>.</td>
                         </tr>
                         <tr>
                             <th scope="row"> <code>{liste_noms_impacts_quantifiés}</code></th>
@@ -344,12 +344,22 @@ Pour la liste {liste_espèces}, chaque élément de la liste contient :
                         <tr>
                             <th scope="row"> <code>{nomScientifique}</code></th>
                             <td> texte</td>
-                            <td> Nom scientifique de l'espèce</td>
+                            <td> Nom scientifique de l'espèce.</td>
                         </tr>
                         <tr>
                             <th scope="row"> <code>{nomVernaculaire}</code></th>
                             <td> texte</td>
-                            <td> Nom vernaculaire de l'espèce</td>
+                            <td> Nom vernaculaire de l'espèce.</td>
+                        </tr>
+                        <tr>
+                            <th scope="row"> <code>{estMinistérielle}</code></th>
+                            <td> booléen</td>
+                            <td>Ce champ vaut <code>true</code> si l'espèce est une espèce de compétence ministérielle, sinon <code>false</code>.</td>
+                        </tr>
+                        <tr>
+                            <th scope="row"> <code>{estCNPN}</code></th>
+                            <td> booléen</td>
+                            <td>Ce champ vaut <code>true</code> si l'espèce est une espèce CNPN, sinon <code>false</code>.</td>
                         </tr>
                     </tbody>
                 </table>

--- a/scripts/commun/outils-espèces.js
+++ b/scripts/commun/outils-espèces.js
@@ -81,7 +81,16 @@ export function espèceLabel(espèce){
  * @param {EspèceProtégéeStrings} _
  * @returns {EspèceProtégée}
  */
-export function espèceProtégéeStringToEspèceProtégée({CD_REF, CD_TYPE_STATUTS, classification, nomsScientifiques, nomsVernaculaires}){
+export function espèceProtégéeStringToEspèceProtégée(
+    {
+        CD_REF, 
+        CD_TYPE_STATUTS, 
+        classification, 
+        nomsScientifiques, 
+        nomsVernaculaires,
+        espèceCNPN,
+        espèceMinistérielle
+    }){
     if(!isClassif(classification)){
         throw new TypeError(`Classification d'espèce non reconnue: ${classification}. Les choix sont : ${[...classificationEtreVivants].join(', ')}`)
     }
@@ -94,6 +103,8 @@ export function espèceProtégéeStringToEspèceProtégée({CD_REF, CD_TYPE_STAT
         classification,
         nomsScientifiques: new Set(nomsScientifiques.split(',')),
         nomsVernaculaires: new Set(nomsVernaculaires.split(',')),
+        espèceCNPN: espèceCNPN === 'O' ? espèceCNPN : undefined,
+        espèceMinistérielle: espèceMinistérielle === 'O' ? espèceMinistérielle : undefined,
     }
 }
 

--- a/scripts/front-end/actions/créerEspècesGroupéesParImpact.js
+++ b/scripts/front-end/actions/créerEspècesGroupéesParImpact.js
@@ -50,6 +50,8 @@ const getterImpactQuantifié = new Map([
  * @prop {string} nomVernaculaire
  * @prop {string} nomScientifique
  * @prop {string} CD_REF
+ * @prop {boolean} espèceMinistérielle
+ * @prop {boolean} espèceCNPN
  * @prop {string[]} détails // impacts quantifiés pour cette activité
  */
 
@@ -87,6 +89,8 @@ export function créerEspècesGroupéesParImpact(espècesImpactées, identifiant
             CD_REF: espèceImpactée.espèce.CD_REF,
             nomScientifique: [...espèceImpactée.espèce.nomsScientifiques][0],
             nomVernaculaire: [...espèceImpactée.espèce.nomsVernaculaires][0],
+            espèceCNPN: espèceImpactée.espèce.espèceCNPN === 'O' ? true : false,
+            espèceMinistérielle: espèceImpactée.espèce.espèceMinistérielle === 'O' ? true : false,
             détails: [...impactsQuantifiés]
                 .map((donnéeSecondaire) => {
                     const funcDetail = getterImpactQuantifié.get(donnéeSecondaire)

--- a/scripts/front-end/actions/générerDocument.js
+++ b/scripts/front-end/actions/générerDocument.js
@@ -21,12 +21,6 @@ import {créerEspècesGroupéesParImpact} from './créerEspècesGroupéesParImpa
  * @see {@link https://betagouv.github.io/pitchou/instruction/document-types/creation.html}
  */
 export function getBalisesGénérationDocument(dossier, espècesImpactées, identifiantPitchouVersActivitéEtImpactsQuantifiés) {
-    const functions = {
-        afficher_nombre,
-        formatter_date,
-        formatter_date_simple
-    }
-
     const {
         nom,
         commentaire_libre,
@@ -113,10 +107,19 @@ export function getBalisesGénérationDocument(dossier, espècesImpactées, iden
         régime_autorisation_environnementale_renseigné: rattaché_au_régime_ae !== null,
         régime_autorisation_environnementale: rattaché_au_régime_ae===null ? 'Non renseigné' : rattaché_au_régime_ae,
         liste_espèces_par_impact: espèces_impacts?.map(({espèces,activité,impactsQuantifiés}) => ({
-            liste_espèces: espèces.map(({nomVernaculaire,nomScientifique, détails}) => ({
+            liste_espèces: espèces.map((
+                {
+                    nomVernaculaire,
+                    nomScientifique, 
+                    détails, 
+                    espèceCNPN, 
+                    espèceMinistérielle
+                }) => ({
                 nomVernaculaire,
                 nomScientifique,
                 liste_impacts_quantifiés:détails,
+                estCNPN: espèceCNPN,
+                estMinistérielle: espèceMinistérielle
             })),
             impact: activité,
             liste_noms_impacts_quantifiés: impactsQuantifiés,
@@ -136,7 +139,10 @@ export function getBalisesGénérationDocument(dossier, espècesImpactées, iden
             précisions_autres_intervenants: scientifique_précisions_autres_intervenants,
         },
         identifiant_pitchou: dossier.id,
-        ...functions,
+        //Fonctions
+        afficher_nombre,
+        formatter_date,
+        formatter_date_simple
     }
 }
 

--- a/scripts/front-end/components/Dossier/DossierProjet.svelte
+++ b/scripts/front-end/components/Dossier/DossierProjet.svelte
@@ -196,28 +196,28 @@
                 ? dossier.durée_intervention + " années"
                 : "Non renseignée"}
         </p>
-
-        <h2>
-            Espèces impactées
-            {#if espècesImpactées}
-                {#await espècesImpactées then espècesImpactées}
-                    {@const {nombreEspècesCNPN, nombreEspècesMinistérielles} = getNombreEspècesMinistérielleCNPN(espècesImpactées)}
-                    <p class="fr-badge fr-badge--blue-ecume">CNPN {nombreEspècesCNPN}</p>
-                    <p class="fr-badge fr-badge--blue-ecume">Ministère {nombreEspècesMinistérielles}</p>
-                {/await}
+        <div class="container-titre-espèces-impactées">
+            <h2>
+                Espèces impactées
+            </h2>
+            {#if dossier.espècesImpactées}
+                <DownloadButton
+                    {makeFileContentBlob}
+                    {makeFilename}
+                    style="width: 15rem;"
+                    classname="fr-btn fr-btn--secondary"
+                    label="Télécharger le fichier des espèces impactées"
+                />
             {/if}
-        </h2>
+        </div>
         {#if dossier.espècesImpactées}
-            <DownloadButton
-                {makeFileContentBlob}
-                {makeFilename}
-                classname="fr-btn fr-btn--secondary"
-                label="Télécharger le fichier des espèces impactées"
-            />
             {#if espècesImpactées}
                 {#await Promise.all([espècesImpactées, promesseRéférentiels])}
                     <Loader></Loader>
                 {:then [espècesImpactées, {identifiantPitchouVersActivitéEtImpactsQuantifiés}]}
+                    {@const {nombreEspècesCNPN, nombreEspècesMinistérielles} = getNombreEspècesMinistérielleCNPN(espècesImpactées)}
+                    <p class="fr-badge fr-badge--blue-ecume">{nombreEspècesCNPN} {nombreEspècesCNPN>1 ? 'espèces' : 'espèce'} CNPN</p>
+                    <p class="fr-badge fr-badge--blue-ecume">{nombreEspècesMinistérielles} {nombreEspècesCNPN>1 ? 'espèces' : 'espèce'} Ministère</p>
                     <EspècesProtégéesGroupéesParImpact {espècesImpactées} {identifiantPitchouVersActivitéEtImpactsQuantifiés} />
                 {/await}
             {/if}
@@ -370,6 +370,23 @@
         & > :nth-child(2) {
             flex: 2;
         }
+    }
+
+    .container-titre-espèces-impactées {
+        display: inline-flex;
+        align-items: center;
+        justify-content: space-between;
+        width: 100%;
+    }
+
+    .container-titre-espèces-impactées h2 {
+        margin: 0;
+        white-space: nowrap;
+    }
+
+    .bouton-telecharger-fichier-espece {
+        background-color: red;
+        width: 15rem;
     }
 
     .pièces-jointes-pétitionnaire{

--- a/scripts/front-end/components/Dossier/DossierProjet.svelte
+++ b/scripts/front-end/components/Dossier/DossierProjet.svelte
@@ -385,7 +385,6 @@
     }
 
     .bouton-telecharger-fichier-espece {
-        background-color: red;
         width: 15rem;
     }
 

--- a/scripts/front-end/components/Dossier/DossierProjet.svelte
+++ b/scripts/front-end/components/Dossier/DossierProjet.svelte
@@ -201,10 +201,12 @@
                 Espèces impactées
             </h2>
             {#if dossier.espècesImpactées}
+                <!-- // Dans Svelte, un composant enfant n'a pas accès aux classes de style définies dans le composant parent dans lequel il est appelé. On utilise donc un style inline. -->
+                {@const styleDownloadButton = "width: 15rem;"}
                 <DownloadButton
                     {makeFileContentBlob}
                     {makeFilename}
-                    style="width: 15rem;"
+                    style={styleDownloadButton}
                     classname="fr-btn fr-btn--secondary"
                     label="Télécharger le fichier des espèces impactées"
                 />

--- a/scripts/front-end/components/Dossier/DossierProjet.svelte
+++ b/scripts/front-end/components/Dossier/DossierProjet.svelte
@@ -22,6 +22,11 @@
 
     const { number_demarches_simplifiées: numdos, numéro_démarche } = dossier;
 
+    // let nombreEspècesCNPNP = $derived(espècesImpactées?.then(
+    //     (espècesImpactées) => espècesImpactées["faune non-oiseau"]
+    //     .reduce((acc, {espèce}) => , 0)
+    // ))
+
     function makeFileContentBlob() {
         envoyerÉvènement({ type: 'téléchargerListeÉspècesImpactées', détails: { dossierId: dossier.id } })
 

--- a/scripts/front-end/components/Dossier/DossierProjet.svelte
+++ b/scripts/front-end/components/Dossier/DossierProjet.svelte
@@ -22,10 +22,31 @@
 
     const { number_demarches_simplifiées: numdos, numéro_démarche } = dossier;
 
-    // let nombreEspècesCNPNP = $derived(espècesImpactées?.then(
-    //     (espècesImpactées) => espècesImpactées["faune non-oiseau"]
-    //     .reduce((acc, {espèce}) => , 0)
-    // ))
+    /**
+     * Calcule le nombre d'espèces CNPN 
+     * et le nombre d'espèce ministérielles
+     * dans la liste des espèces impactées par ce projet
+     * @param {DescriptionMenacesEspèces} _espècesImpactées
+     * @returns { { nombreEspècesCNPN: number, nombreEspècesMinistérielles: number } }
+    */
+    function getNombreEspècesMinistérielleCNPN(_espècesImpactées) {
+        const toutesLesEspècesImpactées = [
+            ...(_espècesImpactées["faune non-oiseau"] ?? []),
+            ...(_espècesImpactées["flore"] ?? []),
+            ...(_espècesImpactées["oiseau"]  ?? []),
+        ]
+
+        const nombres = toutesLesEspècesImpactées.reduce((acc, {espèce}) => {
+                if (espèce.espèceCNPN) {
+                    acc['nombreEspècesCNPN']+=1
+                }
+                if (espèce.espèceMinistérielle) {
+                    acc['nombreEspècesMinistérielles']+=1
+                }
+                return acc
+            }, {nombreEspècesCNPN: 0, nombreEspècesMinistérielles: 0})
+        return nombres
+    }
 
     function makeFileContentBlob() {
         envoyerÉvènement({ type: 'téléchargerListeÉspècesImpactées', détails: { dossierId: dossier.id } })
@@ -176,7 +197,16 @@
                 : "Non renseignée"}
         </p>
 
-        <h2>Espèces impactées</h2>
+        <h2>
+            Espèces impactées
+            {#if espècesImpactées}
+                {#await espècesImpactées then espècesImpactées}
+                    {@const {nombreEspècesCNPN, nombreEspècesMinistérielles} = getNombreEspècesMinistérielleCNPN(espècesImpactées)}
+                    <p class="fr-badge fr-badge--blue-ecume">CNPN {nombreEspècesCNPN}</p>
+                    <p class="fr-badge fr-badge--blue-ecume">Ministère {nombreEspècesMinistérielles}</p>
+                {/await}
+            {/if}
+        </h2>
         {#if dossier.espècesImpactées}
             <DownloadButton
                 {makeFileContentBlob}

--- a/scripts/front-end/components/DownloadButton.svelte
+++ b/scripts/front-end/components/DownloadButton.svelte
@@ -11,6 +11,7 @@
      * @property {string} [label]
      * @property {() => string} makeFilename
      * @property {string} [classname]
+     * @property {string} [style]
      * @property {() => Blob | Promise<Blob>} makeFileContentBlob
      */
 
@@ -19,7 +20,8 @@
         label = "Télécharger",
         makeFilename,
         classname = "fr-btn fr-btn--lg",
-        makeFileContentBlob
+        makeFileContentBlob,
+        style
     } = $props();
 
     async function onClick(){
@@ -33,6 +35,6 @@
 
 </script>
 
-<button class={classname} onclick={onClick}>
+<button class={classname} onclick={onClick} style={style}>
     {label}
 </button>

--- a/scripts/front-end/components/EspècesProtégéesGroupéesParImpact.svelte
+++ b/scripts/front-end/components/EspècesProtégéesGroupéesParImpact.svelte
@@ -36,13 +36,18 @@
                 </tr>
             </thead>
             <tbody>
-                {#each espèces as { nomVernaculaire, nomScientifique, détails }}
+                {#each espèces as { nomVernaculaire, nomScientifique, espèceCNPN, espèceMinistérielle, détails }}
                     <tr>
-                        <td
-                            >{nomVernaculaire} (<i
-                                >{nomScientifique}</i
-                            >)</td
-                        >
+                        <td>
+                            {#if espèceCNPN}
+                                <p class="fr-badge fr-badge--blue-ecume">CNPN</p>
+                            {/if}
+                            {#if espèceMinistérielle}
+                                <p class="fr-badge fr-badge--blue-ecume">Ministère</p>
+                            {/if}
+                            {nomVernaculaire} 
+                            (<i>{nomScientifique}</i>)
+                        </td>
                         {#each détails as détail}
                             <td>{détail}</td>
                         {/each}

--- a/scripts/types/balisesGénérationDocument.d.ts
+++ b/scripts/types/balisesGénérationDocument.d.ts
@@ -8,6 +8,8 @@ interface Espece {
   nomVernaculaire: string;
   nomScientifique: string;
   liste_impacts_quantifiés: string[];
+  estCNPN: boolean;
+  estMinistérielle: boolean;
 }
 
 /**


### PR DESCRIPTION
Cette PR doit être mergée après https://github.com/betagouv/pitchou/pull/534 


Rendre visible l'information Espèce Ministérielle ou CNPN dans : 
- [x] dans l'onglet projet
- [x] dans la génération de document