### PR TITLE
fix(migrations): utilise knex passé en paramètre

### DIFF
--- a/migrations/20241129155523_données-espèces-protégées.js
+++ b/migrations/20241129155523_données-espèces-protégées.js
@@ -1,4 +1,3 @@
-import knexModule from "knex";
 import { readFile } from "node:fs/promises";
 import { dsvFormat } from "d3-dsv";
 
@@ -6,56 +5,53 @@ import {
   importDescriptionMenacesEspècesFromURL,
   descriptionMenacesEspècesToOdsArrayBuffer,
   espèceProtégéeStringToEspèceProtégée,
+  actMetTransArraysToMapBundle,
 } from "../scripts/commun/outils-espèces.js";
-import { actMetTransArraysToMapBundle } from "../scripts/front-end/actions/main.js";
 
 /** @import {ActivitéMenançante, EspèceProtégée, MéthodeMenançante, TransportMenançant} from '../scripts/types/especes.js' */
 /** @import {PitchouState} from '../scripts/front-end/store.js' */
 
 const { parse } = dsvFormat(";");
 
-/** @type { [ActivitéMenançante[], MéthodeMenançante[], TransportMenançant[], any[]] } */
-// @ts-ignore
-const [activitésBrutes, méthodesBrutes, transportsBruts, dataEspèces] = await Promise.all([
-  readFile("data/activités.csv", "utf-8"),
-  readFile("data/méthodes.csv", "utf-8"),
-  readFile("data/transports.csv", "utf-8"),
-  readFile("data/liste-espèces-protégées.csv", "utf-8"),
-]).then((fichiers) => fichiers.map((str) => parse(str)));
-
-const { activités, méthodes, transports } = actMetTransArraysToMapBundle(
-  activitésBrutes,
-  méthodesBrutes,
-  transportsBruts,
-);
-
-/** @type {NonNullable<PitchouState['espèceByCD_REF']>} */
-const espèceByCD_REF = new Map();
-
-for (const espStr of dataEspèces) {
-  /** @type {EspèceProtégée} */
-  // @ts-ignore
-  const espèce = Object.freeze(espèceProtégéeStringToEspèceProtégée(espStr));
-
-  espèceByCD_REF.set(espèce["CD_REF"], espèce);
-}
-
 /**
  * @param { import("knex").Knex } knex
  * @returns { Promise<void> }
  */
 export async function up(knex) {
-  const databaseConnection = knexModule({
-    client: "pg",
-    connection: process.env.DATABASE_URL,
-  });
-
-  const idEtLien = await databaseConnection("dossier")
+  const idEtLien = await knex("dossier")
     .select(["id", "espèces_protégées_concernées"])
     .whereNotNull("espèces_protégées_concernées")
     .andWhereNot("espèces_protégées_concernées", "");
 
   console.log("idEtLien", idEtLien.length);
+
+  if (idEtLien.length === 0) return;
+
+  /** @type { [ActivitéMenançante[], MéthodeMenançante[], TransportMenançant[], any[]] } */
+  // @ts-ignore
+  const [activitésBrutes, méthodesBrutes, transportsBruts, dataEspèces] = await Promise.all([
+    readFile("data/activités.csv", "utf-8"),
+    readFile("data/méthodes.csv", "utf-8"),
+    readFile("data/transports.csv", "utf-8"),
+    readFile("data/liste-espèces-protégées.csv", "utf-8"),
+  ]).then((fichiers) => fichiers.map((str) => parse(str)));
+
+  const { activités, méthodes, transports } = actMetTransArraysToMapBundle(
+    activitésBrutes,
+    méthodesBrutes,
+    transportsBruts,
+  );
+
+  /** @type {NonNullable<PitchouState['espèceByCD_REF']>} */
+  const espèceByCD_REF = new Map();
+
+  for (const espStr of dataEspèces) {
+    /** @type {EspèceProtégée} */
+    // @ts-ignore
+    const espèce = Object.freeze(espèceProtégéeStringToEspèceProtégée(espStr));
+
+    espèceByCD_REF.set(espèce["CD_REF"], espèce);
+  }
 
   const espècesImpactées = [];
 
@@ -88,7 +84,7 @@ export async function up(knex) {
 
   console.log("espèces_impactées", espècesImpactées.length);
 
-  await databaseConnection("espèces_impactées").insert(espècesImpactées);
+  await knex("espèces_impactées").insert(espècesImpactées);
 }
 
 /**
@@ -96,10 +92,5 @@ export async function up(knex) {
  * @returns { Promise<void> }
  */
 export async function down(knex) {
-  const databaseConnection = knexModule({
-    client: "pg",
-    connection: process.env.DATABASE_URL,
-  });
-
-  await databaseConnection("espèces_impactées").delete();
+  await knex("espèces_impactées").delete();
 }

--- a/migrations/20241218144809_données-nettoyage-évènements-phases.js
+++ b/migrations/20241218144809_données-nettoyage-évènements-phases.js
@@ -1,5 +1,3 @@
-import knexModule from "knex";
-
 import { phases } from "../scripts/front-end/affichageDossier.js";
 
 /**
@@ -7,14 +5,7 @@ import { phases } from "../scripts/front-end/affichageDossier.js";
  * @returns { Promise<void> }
  */
 export async function up(knex) {
-  const databaseConnection = knexModule({
-    client: "pg",
-    connection: process.env.DATABASE_URL,
-  });
-
-  await databaseConnection("évènement_phase_dossier")
-    .whereNotIn("phase", [...phases])
-    .delete();
+  await knex("évènement_phase_dossier").whereNotIn("phase", [...phases]).delete();
 }
 
 /**

--- a/migrations/20250102093943_renomme-phase-vérification.js
+++ b/migrations/20250102093943_renomme-phase-vérification.js
@@ -1,5 +1,3 @@
-import knexModule from "knex";
-
 const ancienNom = "Vérification du dossier";
 const nouveauNom = "Étude recevabilité DDEP";
 
@@ -8,14 +6,7 @@ const nouveauNom = "Étude recevabilité DDEP";
  * @returns { Promise<void> }
  */
 export async function up(knex) {
-  const databaseConnection = knexModule({
-    client: "pg",
-    connection: process.env.DATABASE_URL,
-  });
-
-  await databaseConnection("évènement_phase_dossier")
-    .update("phase", nouveauNom)
-    .where({ phase: ancienNom });
+  await knex("évènement_phase_dossier").update("phase", nouveauNom).where({ phase: ancienNom });
 }
 
 /**
@@ -23,12 +14,5 @@ export async function up(knex) {
  * @returns { Promise<void> }
  */
 export async function down(knex) {
-  const databaseConnection = knexModule({
-    client: "pg",
-    connection: process.env.DATABASE_URL,
-  });
-
-  await databaseConnection("évènement_phase_dossier")
-    .update("phase", ancienNom)
-    .where({ phase: nouveauNom });
+  await knex("évènement_phase_dossier").update("phase", ancienNom).where({ phase: nouveauNom });
 }

--- a/migrations/20250422125650_refacto-dossier-espèces-impactées.js
+++ b/migrations/20250422125650_refacto-dossier-espèces-impactées.js
@@ -1,30 +1,17 @@
-import knexModule from "knex";
-
 /**
  * @param { import("knex").Knex } knex
  * @returns { Promise<void> }
  */
 export async function up(knex) {
-  const databaseConnection = knexModule({
-    client: "pg",
-    connection: process.env.DATABASE_URL,
-  });
+  const fichiers = await knex("fichier").select(["id", "dossier"]).whereNotNull("dossier");
 
-  const fichiers = await databaseConnection("fichier")
-    .select(["id", "dossier"])
-    .whereNotNull("dossier");
-
-  const updatesDone = Promise.all(
+  await Promise.all(
     fichiers.map((f) => {
       const { id: fichierId, dossier: dossierId } = f;
 
-      return databaseConnection("dossier")
-        .update({ espèces_impactées: fichierId })
-        .where({ id: dossierId });
+      return knex("dossier").update({ espèces_impactées: fichierId }).where({ id: dossierId });
     }),
   );
-
-  return updatesDone;
 }
 
 /**
@@ -32,10 +19,5 @@ export async function up(knex) {
  * @returns { Promise<void> }
  */
 export async function down(knex) {
-  const databaseConnection = knexModule({
-    client: "pg",
-    connection: process.env.DATABASE_URL,
-  });
-
-  return databaseConnection("dossier").update({ espèces_impactées: null });
+  await knex("dossier").update({ espèces_impactées: null });
 }


### PR DESCRIPTION
Avec ce PR, on pourra lancer les migrations sur une base de donnée vierge, sans avoir des erreurs