### PR TITLE
fix(sync): gère entreprise=null dans makeDossiersPourSynchronisation

### DIFF
--- a/outils/synchronisation-ds/makeDossiersPourSynchronisation.js
+++ b/outils/synchronisation-ds/makeDossiersPourSynchronisation.js
@@ -116,9 +116,9 @@ export function getDonnéesPersonnesEntreprises88444(dossierDS, pitchouKeyToCham
   if (SIRETChamp) {
     const etablissement = SIRETChamp.etablissement;
     if (etablissement) {
-      const { siret, address = {}, entreprise = {} } = etablissement;
+      const { siret, address = {}, entreprise } = etablissement;
       const { streetAddress, postalCode, cityName } = address;
-      const { raisonSociale } = entreprise;
+      const { raisonSociale } = entreprise ?? {};
 
       demandeur_personne_morale = {
         siret,


### PR DESCRIPTION
DS peut retourner `entreprise: null` (pas seulement `undefined`), ce qui faisait échouer le déstructurage avec `entreprise = {}` (le défaut ne s'applique que pour undefined). La synchronisation crush alors sur le premier dossier concerné, interrompant tout le run.

Quand DN renvoie:
```js
  etablissement: {
    siret: "...",
    address: {...},
    entreprise: null   // ← null
  }
```
Code originel:
```js
  const { siret, address = {}, entreprise = {} } = etablissement;
  //                            ^^^^^^^^^^^^^^^ la valeur par défaut = {} ne s'applique pas car la valeur est null, pas undefined
  const { raisonSociale } = entreprise;  // entreprise is null → TypeError
```