### PR TITLE
fix(sync): rattache les pièces jointes pétitionnaire partagées entre dossiers

### DIFF
--- a/migrations/20260527182955_unique-dossier-fichier-pieces-jointes-petitionnaire.js
+++ b/migrations/20260527182955_unique-dossier-fichier-pieces-jointes-petitionnaire.js
@@ -1,0 +1,25 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function up(knex) {
+  await knex.schema.alterTable(
+    "arête_dossier__fichier_pièces_jointes_pétitionnaire",
+    function (table) {
+      table.unique(["dossier", "fichier"], { indexName: "arête_dossier_pj_pétitionnaire_unique" });
+    },
+  );
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function down(knex) {
+  await knex.schema.alterTable(
+    "arête_dossier__fichier_pièces_jointes_pétitionnaire",
+    function (table) {
+      table.dropUnique(["dossier", "fichier"], "arête_dossier_pj_pétitionnaire_unique");
+    },
+  );
+}

--- a/outils/synchronisation-ds/téléchargerNouveauxFichiers.js
+++ b/outils/synchronisation-ds/téléchargerNouveauxFichiers.js
@@ -79,7 +79,10 @@ export default async function téléchargerNouveauxFichiers(candidatsFichiers, t
     transaction,
   );
 
-  const fichierHashDéjàEnBDD = new Set(fichiersDéjaEnBDD.map(makeFichierHash));
+  const fichierIdParHashDéjàEnBDD = new Map(
+    // @ts-ignore
+    fichiersDéjaEnBDD.map((f) => [makeFichierHash(f), f.id]),
+  );
 
   //console.log('fichiersDéjaEnBDD', fichiersDéjaEnBDD)
   //console.log('candidatsFichiersBDD', candidatsFichiersBDD)
@@ -90,7 +93,7 @@ export default async function téléchargerNouveauxFichiers(candidatsFichiers, t
     // @ts-ignore
     [...candidatsFichiersBDD]
       .map(([number, fichiers]) => {
-        return [number, fichiers.filter((f) => !fichierHashDéjàEnBDD.has(makeFichierHash(f)))];
+        return [number, fichiers.filter((f) => !fichierIdParHashDéjàEnBDD.has(makeFichierHash(f)))];
       })
       // @ts-ignore
       .filter(([_, fichiers]) => fichiers.length >= 1),
@@ -167,9 +170,25 @@ export default async function téléchargerNouveauxFichiers(candidatsFichiers, t
     });
   });
 
-  /** @type {ReturnMapEntryData[]} */
-  const ret = (await Promise.all(retMapDataPs)) // ignore download errors
-    .filter((x) => x !== undefined);
+  const nouveauxFichiersParDossier = new Map(
+    (await Promise.all(retMapDataPs)).filter((x) => x !== undefined),
+  );
 
-  return new Map(ret);
+  // Pour chaque dossier, on retourne les ids de tous les fichiers qui le concernent — qu'ils
+  // viennent d'être téléchargés ou qu'ils étaient déjà en BDD (matchés par hash). Le consommateur
+  // peut ainsi créer les arêtes de jointure dans les deux cas.
+  const fichiersParDossier = new Map();
+  for (const [numéroDossier, candidats] of candidatsFichiersBDD) {
+    const idsFichiersDéjàEnBDD = candidats
+      .map((c) => fichierIdParHashDéjàEnBDD.get(makeFichierHash(c)))
+      .filter((id) => id !== undefined);
+
+    const idsFichiersNouveaux = nouveauxFichiersParDossier.get(numéroDossier) ?? [];
+
+    const tousLesIds = [...idsFichiersDéjàEnBDD, ...idsFichiersNouveaux];
+
+    if (tousLesIds.length >= 1) fichiersParDossier.set(numéroDossier, tousLesIds);
+  }
+
+  return fichiersParDossier;
 }

--- a/scripts/server/database/arête_dossier__fichier_pièces_jointes_pétitionnaire.js
+++ b/scripts/server/database/arête_dossier__fichier_pièces_jointes_pétitionnaire.js
@@ -7,6 +7,7 @@
 
 import trouverCandidatsFichiersÀTélécharger from "../../../outils/synchronisation-ds/trouverCandidatsFichiersÀTélécharger.js";
 import { directDatabaseConnection } from "../database.js";
+import { supprimerFichiersSansAutresRéférences } from "./fichier.js";
 
 /** @typedef {keyof DossierDemarcheNumerique88444} ChampFormulaire */
 
@@ -55,32 +56,38 @@ export async function synchroniserFichiersPiècesJointesPétitionnaireDepuisDS88
   //console.log('dossierIds', dossierIds)
   //console.log('checksumsDS', checksumsDS)
 
-  // Trouver les fichiers qui sont en base de données, mais ne sont plus dans DS
-  const fichierIdsEnBDDMaisPlusDansDS = await databaseConnection("dossier")
-    .select(["fichier.id as id"])
-    .leftJoin("arête_dossier__fichier_pièces_jointes_pétitionnaire", {
-      "arête_dossier__fichier_pièces_jointes_pétitionnaire.dossier": "dossier.id",
-    })
-    .leftJoin("fichier", {
-      "fichier.id": "arête_dossier__fichier_pièces_jointes_pétitionnaire.fichier",
-    })
-    .whereIn("dossier.id", [...dossierIds])
-    .andWhere("DS_checksum", "not in", [...checksumsDS]);
-
-  //console.log('fichier ids orphelins', fichierIdsEnBDDMaisPlusDansDS)
+  // Trouver les (dossier, fichier) à délier : fichiers liés à un dossier du lot via la jointure PJ pétitionnaire,
+  // mais dont le DS_checksum n'est plus dans la liste des candidats DS pour ces dossiers
+  const arêtesÀSupprimer = await databaseConnection(
+    "arête_dossier__fichier_pièces_jointes_pétitionnaire as a",
+  )
+    .select(["a.dossier as dossier", "a.fichier as fichier"])
+    .innerJoin("fichier as f", "f.id", "a.fichier")
+    .whereIn("a.dossier", [...dossierIds])
+    .andWhere("f.DS_checksum", "not in", [...checksumsDS]);
 
   /** @type {Promise<any>} */
   let fichiersOrphelinsNettoyés = Promise.resolve();
 
-  if (fichierIdsEnBDDMaisPlusDansDS.length >= 1) {
-    // supprimer les fichier
-    // les arêtes correspondantes sont supprimées via le ON DELETE CASCADE
-    fichiersOrphelinsNettoyés = databaseConnection("fichier")
-      .delete()
-      .whereIn(
-        "id",
-        fichierIdsEnBDDMaisPlusDansDS.map((f) => f.id),
+  if (arêtesÀSupprimer.length >= 1) {
+    const fichierIdsCandidatsÀSupprimer = [...new Set(arêtesÀSupprimer.map((a) => a.fichier))];
+
+    fichiersOrphelinsNettoyés = (async () => {
+      // 1. Délier : supprimer les arêtes PJ pétitionnaire concernées (le fichier peut encore servir ailleurs)
+      await databaseConnection("arête_dossier__fichier_pièces_jointes_pétitionnaire")
+        .delete()
+        .whereIn(
+          ["dossier", "fichier"],
+          arêtesÀSupprimer.map((a) => [a.dossier, a.fichier]),
+        );
+
+      // 2. Supprimer les fichiers maintenant que les arêtes sont parties, uniquement
+      //    s'ils ne sont plus référencés ailleurs
+      await supprimerFichiersSansAutresRéférences(
+        fichierIdsCandidatsÀSupprimer,
+        databaseConnection,
       );
+    })();
   }
 
   const arêtesFichierDossierPiècesJointePétitionnaires = [
@@ -97,7 +104,10 @@ export async function synchroniserFichiersPiècesJointesPétitionnaireDepuisDS88
   if (arêtesFichierDossierPiècesJointePétitionnaires.length >= 1) {
     nouveauxFichiersSynchronisés = databaseConnection(
       "arête_dossier__fichier_pièces_jointes_pétitionnaire",
-    ).insert(arêtesFichierDossierPiècesJointePétitionnaires);
+    )
+      .insert(arêtesFichierDossierPiècesJointePétitionnaires)
+      .onConflict(["dossier", "fichier"])
+      .ignore();
   }
 
   return Promise.all([fichiersOrphelinsNettoyés, nouveauxFichiersSynchronisés]);

--- a/scripts/server/database/espèces_impactées.js
+++ b/scripts/server/database/espèces_impactées.js
@@ -1,4 +1,5 @@
 import { directDatabaseConnection } from "../database.js";
+import { supprimerFichiersSansAutresRéférences } from "./fichier.js";
 
 /** @import {default as Fichier} from '../../../scripts/types/database/public/Fichier.ts' */
 /** @import {DossierDS88444} from '../../types/démarche-numérique/apiSchema.ts' */
@@ -31,13 +32,8 @@ export async function synchroniserFichiersEspècesImpactéesDepuisDS88444(
   });
 
   // Supprimer les fichiers qui étaient attachés à un dossier et ne sont plus pertinents
-  return Promise.all(updatePs).then(() => {
-    const fichiersOrphelinsIds = fichiersIdPrécédents.map(
-      ({ espèces_impactées }) => espèces_impactées,
-    );
+  await Promise.all(updatePs);
 
-    if (fichiersOrphelinsIds.length >= 1) {
-      return databaseConnection("fichier").delete().whereIn("id", fichiersOrphelinsIds);
-    }
-  });
+  const fichiersAncienIds = fichiersIdPrécédents.map(({ espèces_impactées }) => espèces_impactées);
+  await supprimerFichiersSansAutresRéférences(fichiersAncienIds, databaseConnection);
 }

--- a/scripts/server/database/fichier.js
+++ b/scripts/server/database/fichier.js
@@ -34,7 +34,7 @@ export function trouverFichiersExistants(
   databaseConnection = directDatabaseConnection,
 ) {
   return databaseConnection("fichier")
-    .select(["DS_checksum", "nom", "media_type"])
+    .select(["id", "DS_checksum", "nom", "media_type"])
     .whereIn(
       ["DS_checksum", "nom", "media_type"],
       // @ts-ignore
@@ -69,4 +69,46 @@ export function getFichier(fichierId, databaseConnection = directDatabaseConnect
  */
 export function supprimerFichier(id, databaseConnection = directDatabaseConnection) {
   return databaseConnection("fichier").delete().where({ id });
+}
+
+// Toutes les tables/colonnes qui peuvent référencer un fichier (cf. les FK vers `fichier` dans les migrations).
+// Centralisé ici pour que `supprimerFichiersSansAutresRéférences` reste exhaustive.
+const FICHIER_REFERENCES = [
+  { table: "arête_dossier__fichier_pièces_jointes_pétitionnaire", column: "fichier" },
+  { table: "dossier", column: "espèces_impactées" },
+  { table: "décision_administrative", column: "fichier" },
+  { table: "avis_expert", column: "saisine_fichier" },
+  { table: "avis_expert", column: "avis_fichier" },
+];
+
+/**
+ * Supprime du `fichier` uniquement les IDs qui ne sont plus référencés par aucune autre table.
+ * Préserve les fichiers partagés entre plusieurs usages (un même contenu peut être à la fois
+ * une PJ pétitionnaire, un fichier espèces impactées, un avis expert, etc.).
+ *
+ * @param {Fichier['id'][]} fichierIds
+ * @param {Knex.Transaction | Knex} [databaseConnection]
+ * @returns {Promise<Fichier['id'][]>} les IDs effectivement supprimés
+ */
+export async function supprimerFichiersSansAutresRéférences(
+  fichierIds,
+  databaseConnection = directDatabaseConnection,
+) {
+  if (fichierIds.length === 0) return [];
+
+  const stillReferenced = new Set();
+  for (const { table, column } of FICHIER_REFERENCES) {
+    const rows = await databaseConnection(table).select(column).whereIn(column, fichierIds);
+    for (const r of rows) {
+      if (r[column] !== null) stillReferenced.add(r[column]);
+    }
+  }
+
+  const àSupprimer = fichierIds.filter((id) => !stillReferenced.has(id));
+
+  if (àSupprimer.length >= 1) {
+    await databaseConnection("fichier").delete().whereIn("id", àSupprimer);
+  }
+
+  return àSupprimer;
 }


### PR DESCRIPTION
# Problème 
Certains dossiers s'affichaient avec "0 pièces jointes" dans Pitchou alors que DS en signalait plusieurs. Le cas typique : un fichier identique (par exemple la même image démo) déposé sur deux dossiers DS différents. Le premier  dossier synchronisé se voyait correctement rattacher le fichier, mais le second n'avait aucune arête de jointure et apparaissait vide.

La cause se trouvait dans `téléchargerNouveauxFichiers`. La fonction faisait deux choses utiles:
- dédupliquer le contenu (pas la peine de retélécharger un fichier déjà en BDD)
- retourner les ids des fichiers à rattacher au dossier

mais confondait les deux : une fois un fichier filtré par le dédoublonnage, son id était jeté. Le consommateur (qui crée les arêtes (dossier, fichier)) n'avait donc rien à insérer pour les dossiers dont les fichiers existaient déjà.

# Solution
Le correctif principal modifie `téléchargerNouveauxFichiers` pour qu'il retourne, par dossier, l'union des fichiers nouvellement téléchargés et des fichiers existants matchés par hash. Le consommateur dispose ainsi de l'ensemble complet pour insérer les arêtes manquantes.

Cette modification a fait remonter deux bugs voisins qu'il a fallu corriger dans la foulée pour que la synchronisation se termine sans erreur. D'abord, l'ancien nettoyage "orphelin" supprimait des lignes fichier sans vérifier si elles étaient référencées ailleurs (par exemple un même fichier servant à la fois de PJ pétitionnaire et de fichier espèces impactées) ; il en résultait une FOREIGN KEY violation quand l'insertion d'une arête tentait de cibler une ligne fichier venant d'être supprimée par une autre étape du même sync.

Le code de suppression a été refactoré en deux temps:
- d'abord supprimer l'arête de jointure (l'usage qui n'existe plus)
- ensuite supprimer le fichier uniquement s'il n'est plus référencé par aucune des cinq tables qui peuvent pointer dessus

Cette logique est centralisée dans un nouvel utilitaire `supprimerFichiersSansAutresRéférences` réutilisé par les deux points de synchronisation des fichiers (espèces impactées et PJ pétitionnaire). La suppression effective des fichiers vraiment retirés de DS est conservée mais elle ne s'active plus quand un autre usage légitime existe.

Ensuite, la table `arête_dossier__fichier_pièces_jointes_pétitionnaire` n'avait pas de contrainte d'unicité sur (dossier, fichier). Une nouvelle migration l'ajoute, et l'insertion utilise désormais `ON CONFLICT (dossier, fichier) DO NOTHING`. Cela garantit l'idempotence :  on peut relancer la synchronisation sans risquer de doublons ni d'erreur.

En résumé : un dossier DS qui réutilise un fichier déjà connu de Pitchou voit désormais son lien correctement créé, le nettoyage des fichiers retirés de DS reste actif mais respecte les autres usages, et la synchronisation est idempotente.