### PR TITLE
chore(docker): passe pgdata en volume nommé pour éviter les soucis de permission

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -26,7 +26,7 @@ services:
     ports:
       - "5432:5432"
     volumes:
-      - ./pgdata:/var/lib/postgresql/data
+      - pgdata:/var/lib/postgresql/data
       - ./backups:/var/lib/pitchou/backups
 
   pgadmin:
@@ -43,3 +43,6 @@ services:
       PGADMIN_CONFIG_SERVER_HEARTBEAT_TIMEOUT: 3600 # secondes = une heure
     restart: unless-stopped
     stop_grace_period: 2s
+
+volumes:
+  pgdata:


### PR DESCRIPTION
Le dossier ./pgdata était monté en bind mount dans le conteneur Postgres. Sous Linux, Docker écrit alors dans ce dossier en tant que l'utilisateur postgres du conteneur (uid 999), ce qui rend ./pgdata inaccessible à l'utilisateur courant sur l'hôte. Conséquence concrète : les outils qui parcourent le repo entier (prettier, svelte-check, etc.) échouent avec une erreur de permission. Sur macOS le problème ne se manifeste pas grâce au mapping d'uid de Docker Desktop, ce qui explique pourquoi le bug est resté un moment.

Le correctif passe pgdata d'un bind mount à un volume nommé géré par Docker. Les données vivent désormais dans /var/lib/docker/volumes/pitchou-3_pgdata/ (ou équivalent selon l'installation), hors du repo, et l'utilisateur courant n'a plus besoin de quoi que ce soit pour faire tourner prettier ou svelte-check.

Ce que les autres contributeurs doivent faire après avoir mergé :
- Redémarrer Docker pour créer le nouveau volume (`just dev-stop` puis `just dev-docker`)
- puis supprimer l'ancien dossier local devenu inutile: `sudo rm -rf pgdata`
