### PR TITLE
chore(docker): supprime le service tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,13 +176,11 @@ Puis lancer `node outils/liste-espèces.js` pour régénérer une liste d'espèc
 
 #### En dev
 
-depuis le container du serveur
+`just sync-ds` (dernières heures par défaut)
 
-`docker exec tooling node --env-file=.env outils/sync-démarche-numérique.js --IdSchemaDS derogation-especes-protegees` (dernières heures par défaut)
+`just sync-ds 2025-06-01` (synchroniser les dossiers modifiés depuis le 1 juin 2025)
 
-`docker exec tooling node --env-file=.env outils/sync-démarche-numérique.js --IdSchemaDS derogation-especes-protegees --lastModified 2025-06-01`(synchroniser les dossiers modifiés depuis le 1 juin 2025)
-
-`docker exec tooling node --env-file=.env outils/sync-démarche-numérique.js --IdSchemaDS derogation-especes-protegees --lastModified 2024-01-01` (synchroniser tous les dossiers, date très distantes)
+`just sync-ds 2024-01-01` (synchroniser tous les dossiers, date très distantes)
 
 #### En prod
 
@@ -206,15 +204,15 @@ scalingo --app especes-protegees run --size 2XL 'node outils/sync-démarche-num�
 
 Utile pour tester rapidement en local après un restore de backup en tant qu'une personne en particulier
 
-`docker exec tooling node outils/afficher-liens-de-connexion.js --emails adresse1@e.mail,adresse2@e.mail`
+`node outils/afficher-liens-de-connexion.js --emails adresse1@e.mail,adresse2@e.mail`
 
 Pour les lien de connexion en production :
 
-`docker exec tooling node outils/afficher-liens-de-connexion.js --emails adresse1@e.mail,adresse2@e.mail --prod`
+`node outils/afficher-liens-de-connexion.js --emails adresse1@e.mail,adresse2@e.mail --prod`
 
 Pour donner l'origine de manière libre :
 
-`docker exec tooling node outils/afficher-liens-de-connexion.js --emails adresse1@e.mail,adresse2@e.mail --origin 'http://example.net'`
+`node outils/afficher-liens-de-connexion.js --emails adresse1@e.mail,adresse2@e.mail --origin 'http://example.net'`
 
 ### GeoMCE
 
@@ -243,12 +241,12 @@ En production :
 `scalingo --app especes-protegees run "node outils/aarri/supprimer-evenements.js"`
 
 En dev :
-`docker exec tooling node outils/aarri/supprimer-evenements.js`
+`node outils/aarri/supprimer-evenements.js`
 
 Pour nettoyer tous les évènements concernant une personne spécifique :
 
-`docker exec tooling node outils/aarri/supprimer-evenements.js --email david@example.net`
+`node outils/aarri/supprimer-evenements.js --email david@example.net`
 
 Pour nettoyer tous les évènements plus vieux que x semaines
 
-`docker exec tooling node outils/aarri/supprimer-evenements.js --conserver-dernières-semaines 20`
+`node outils/aarri/supprimer-evenements.js --conserver-dernières-semaines 20`

--- a/compose.yml
+++ b/compose.yml
@@ -1,19 +1,4 @@
 services:
-  tooling:
-    image: node:22
-    container_name: tooling
-    depends_on:
-      - db
-    volumes:
-      - ./:/app
-    working_dir: /app
-    command: sleep 365d
-    environment:
-      HOME: /app
-      DATABASE_URL: "postgresql://dev:dev_password@postgres_db:5432/especes_pro_3731"
-    user: "${DOCKER_UID}:${DOCKER_GID}"
-    stop_grace_period: 1s
-
   db:
     image: postgres:15.7
     container_name: postgres_db

--- a/justfile
+++ b/justfile
@@ -1,3 +1,5 @@
+set dotenv-load
+
 # Liste les recettes disponibles
 default:
     @just --list
@@ -40,9 +42,9 @@ build:
 dev:
     vite dev
 
-# Lance les conteneurs Docker de support (Postgres + tooling + pgadmin)
+# Lance les conteneurs Docker de support (Postgres + pgadmin)
 dev-docker:
-    DOCKER_UID="$(id -u)" DOCKER_GID="$(id -g)" docker compose up
+    docker compose up
 
 # Arrête les conteneurs Docker
 dev-stop:
@@ -58,19 +60,23 @@ dev-restart:
 
 # Applique les migrations en attente
 migrate-up:
-    docker exec tooling npx knex migrate:up --env docker_dev
+    knex migrate:up --env docker_dev
 
 # Annule la dernière migration appliquée
 migrate-down:
-    docker exec tooling npx knex migrate:down --env docker_dev
+    knex migrate:down --env docker_dev
 
 # Applique toutes les migrations en attente
 migrate-latest:
-    docker exec tooling npx knex migrate:latest --env docker_dev
+    knex migrate:latest --env docker_dev
 
 # Insère les données de dev en base
 seed-dev:
     pnpm run seed:dev
+
+# Synchronise les dossiers depuis Démarches Simplifiées (sans argument : dernières heures ; sinon depuis la date passée, ex: just sync-ds 2025-06-01)
+sync-ds lastModified="":
+    node outils/sync-démarche-numérique.js --IdSchemaDS derogation-especes-protegees {{ if lastModified == "" { "" } else { "--lastModified " + lastModified } }}
 
 # Génère tous les types (base de données + Démarche Numérique)
 build-types:
@@ -79,7 +85,7 @@ build-types:
 
 # Génère les types depuis le schéma de la base de données
 build-types-db:
-    docker exec tooling npx kanel -d postgresql://dev:dev_password@postgres_db:5432/especes_pro_3731 -o ./scripts/types/database
+    kanel -d "$DATABASE_URL" -o ./scripts/types/database
 
 # Génère les types des schémas Démarche Numérique
 build-types-ds:


### PR DESCRIPTION
Le service tooling a été ajouté à l'époque où l'application tournait entièrement dans Docker (serveur Fastify + frontend dans des conteneurs). Comme les contributeurs n'avaient pas besoin d'avoir Node installé localement, il fallait un environnement avec Node et les dépendances du projet, accessible via docker exec, pour lancer les scripts CLI (migrations knex, génération de types kanel, synchronisation DS, outils ponctuels). Ce conteneur avait également l'avantage de pouvoir joindre Postgres via le hostname postgres_db du réseau Docker.

Depuis la migration vers SvelteKit (#566), le serveur Fastify a été supprimé et le dev tourne désormais sur le host via just dev (Vite). Avoir Node + pnpm installés localement est donc devenu un prérequis de fait pour développer Pitchou. Dès lors, passer par docker exec tooling pour exécuter des scripts node n'apporte plus rien : on a déjà tout sur le host, et la connexion à Postgres se fait via le port publié localhost:5433.