### PR TITLE
fix(sync): évite les décisions administratives en double

### DIFF
--- a/outils/synchronisation-ds/makeDossiersPourSynchronisation.ts
+++ b/outils/synchronisation-ds/makeDossiersPourSynchronisation.ts
@@ -264,8 +264,7 @@ function makeÉvènementsPhaseDossierFromTraitementsDS(
 
 /**
  * Synchronisation des décisions administratives
- * Les fichiers téléchargés correspondent à ceux qui n'avaient pas été téléchargés et donc sûrement à
- * une nouvelle décision administrative qui n'est pas encore en BDD
+ * On crée une décision administrative pour le dossier qui a un fichier de motivation associé.
  *
  * On utilise le dernier traitement du dossier pour déterminer le type de décision administrative (acceptation, refus).
  * `idPitchouDuDossier`: si le dossier est à insérer et pas à updater, alors l'id du dossier n'existe pas encore et il est défini à null.
@@ -277,9 +276,9 @@ function makeDécisionAdministrativeFromTraitementDS(
 ): PartialBy<DécisionAdministrativeInitializer, "dossier">[] {
   const décisionsAdministratives: PartialBy<DécisionAdministrativeInitializer, "dossier">[] = [];
 
-  if (fichiersMotivationTéléchargés && fichiersMotivationTéléchargés.size >= 1) {
-    const fichierMotivationId = fichiersMotivationTéléchargés.get(dossierDS.number);
+  const fichierMotivationId = fichiersMotivationTéléchargés?.get(dossierDS.number);
 
+  if (fichierMotivationId) {
     let type: TypeDécisionAdministrative = "Autre décision";
 
     const traitements = dossierDS.traitements;

--- a/scripts/server/database/dossier.ts
+++ b/scripts/server/database/dossier.ts
@@ -91,6 +91,43 @@ export async function getDossierMessages(
 
 const varcharKeys: (keyof Pick<Dossier, "nom" | "ddep_nécessaire">)[] = ["nom", "ddep_nécessaire"];
 
+type DecisionAdministrativeToInsert = NonNullable<
+  DossierPourInsert["décision_administrative"]
+>[number];
+
+/**
+ * Keeps only the decisions administratives whose (dossier, fichier) pair
+ * is not already present in the database.
+ */
+async function getDecisionsAdministrativesNotInDB(
+  decisions: DecisionAdministrativeToInsert[],
+  databaseConnection: Knex.Transaction | Knex,
+): Promise<DecisionAdministrativeToInsert[]> {
+  const fichiers = decisions
+    .map((decision) => decision.fichier)
+    .filter((fichier): fichier is Fichier["id"] => fichier !== undefined && fichier !== null);
+
+  if (fichiers.length === 0) {
+    return decisions;
+  }
+
+  const decisionsInDB = await databaseConnection("décision_administrative")
+    .select(["dossier", "fichier"])
+    .whereIn("fichier", fichiers);
+
+  const dossierFichierKey = (decision: DecisionAdministrativeToInsert) =>
+    `${decision.dossier}:${decision.fichier}`;
+
+  const keysInDB = new Set(decisionsInDB.map(dossierFichierKey));
+
+  const isAlreadyInDB = (decision: DecisionAdministrativeToInsert) =>
+    keysInDB.has(dossierFichierKey(decision));
+
+  const newDecisions = decisions.filter((decision) => !isAlreadyInDB(decision));
+
+  return newDecisions;
+}
+
 export async function dumpDossiers(
   dossiersPourInsert: DossierPourInsert[],
   dossiersPourUpdate: DossierPourUpdate[],
@@ -205,6 +242,11 @@ export async function dumpDossiers(
     .filter((x) => x !== undefined)
     .flat();
 
+  const decisionsAdministrativesToInsert = await getDecisionsAdministrativesNotInDB(
+    décisionAdministrativeDossier,
+    databaseConnection,
+  );
+
   const databaseOperations = [
     évènementsPhaseDossier.length > 0
       ? databaseConnection("évènement_phase_dossier")
@@ -217,8 +259,8 @@ export async function dumpDossiers(
       ? databaseConnection("avis_expert").insert(avisExpertDossier)
       : Promise.resolve([]),
 
-    décisionAdministrativeDossier.length > 0
-      ? databaseConnection("décision_administrative").insert(décisionAdministrativeDossier)
+    decisionsAdministrativesToInsert.length > 0
+      ? databaseConnection("décision_administrative").insert(decisionsAdministrativesToInsert)
       : Promise.resolve([]),
 
     arêtePersonneSuitDossierDossier.length > 0


### PR DESCRIPTION
  ### Problème

  Sur certains dossiers, la section « Décisions administratives » était répétée des dizaines de fois (ex. un dossier avec 38
  décisions « Arrêté dérogation » vides, tous les champs nuls sauf le type). Au total ~8500 décisions vides réparties sur ~2650  dossiers.

  Ce ne sont pas des doublons d'affichage : les lignes existent réellement en base, créées par la synchronisation Démarche Numérique.

  ### Cause

  Le bug est en deux parties :

  - Latent depuis le départ : `makeDécisionAdministrativeFromTraitementDS` crée une décision dès que `fichiersMotivationTéléchargés` n'est pas vide (.size >= 1), pour tous les dossiers du lot, alors que le fichier est récupéré par dossier avec `.get(number)`, qui renvoie souvent `undefined`. Un dossier sans fichier de motivation se retrouvait donc avec une décision vide. De plus `dumpDossiers` insère ces décisions sans déduplication, y compris pour les dossiers déjà existants.
  - Déclencheur : depuis le rattachement des fichiers partagés entre dossiers, `téléchargerNouveauxFichiers` renvoie aussi les fichiers déjà présents en base (pas seulement les nouveaux). `fichiersMotivationTéléchargés` est donc quasiment toujours non vide. Combiné à la fenêtre glissante de 12h et au cron toutes les 10 min, chaque dossier récemment modifié accumulait une décision vide à chaque passage.

  ### Correctifs

  1. `makeDécisionAdministrativeFromTraitementDS`: on ne crée une décision que si ce dossier a effectivement un fichier de motivation associé, au lieu de se baser sur la taille globale de la map. Plus de décisions vides (fichier = undefined).

  2. `dumpDossiers`: avant l'insertion, on écarte les décisions dont le couple `(dossier, fichier)` existe déjà en base
  (`getDecisionsAdministrativesNotInDB`). Une re-synchronisation d'un dossier dont le fichier de motivation est déjà stocké ne recrée donc plus de doublon. La déduplication est limitée à la synchro : les ajouts manuels ne sont pas concernés.

###   Nettoyage des données

  Les ~8500 décisions vides existantes seront supprimées par requête SQL après déploiement de ce correctif (sinon le cron les recrée dans la fenêtre de 12h), en conservant les décisions légitimes (celles avec un fichier, des dates ou des prescriptions).