### PR TITLE
fix(dossier): corrige erreur 500 au téléchargement

### DIFF
--- a/scripts/front-end/components/Dossier/Avis/FormulaireAvisExpert.svelte
+++ b/scripts/front-end/components/Dossier/Avis/FormulaireAvisExpert.svelte
@@ -152,6 +152,7 @@
           <a
             class="fr-btn fr-btn--secondary fr-btn--sm"
             href={avisExpertInitial.saisine_fichier_url}
+            data-sveltekit-reload
           >
             Télécharger le fichier de la saisine
           </a>
@@ -191,7 +192,11 @@
           >
         </label>
         {#if avisExpertInitial?.avis_fichier_url}
-          <a class="fr-btn fr-btn--secondary fr-btn--sm" href={avisExpertInitial.avis_fichier_url}>
+          <a
+            class="fr-btn fr-btn--secondary fr-btn--sm"
+            href={avisExpertInitial.avis_fichier_url}
+            data-sveltekit-reload
+          >
             Télécharger le fichier de l'avis
           </a>
         {:else}

--- a/scripts/front-end/components/Dossier/Contrôles/DécisionsAdministratives.svelte
+++ b/scripts/front-end/components/Dossier/Contrôles/DécisionsAdministratives.svelte
@@ -210,7 +210,7 @@
 
     <div class="fr-mb-2w">
       {#if fichier_url}
-        <a class="fr-btn fr-btn--secondary fr-btn--sm" href={fichier_url}>
+        <a class="fr-btn fr-btn--secondary fr-btn--sm" href={fichier_url} data-sveltekit-reload>
           Télécharger le fichier de l'arrếté
         </a>
       {:else}

--- a/scripts/front-end/components/Dossier/DossierProjet.svelte
+++ b/scripts/front-end/components/Dossier/DossierProjet.svelte
@@ -320,7 +320,7 @@
       <ul class="pièces-jointes-pétitionnaire">
         {#each dossier.piècesJointesPétitionnaires as { url, nom, media_type, taille }}
           <li>
-            <a class="fr-link fr-link--download" href={url} title={nom}>
+            <a class="fr-link fr-link--download" href={url} title={nom} data-sveltekit-reload>
               <!--
                             On coupe le nom parce que s'il se met sur 2 lignes, le DSFR fait que la deuxième
                             ligne se superpose avec les détails en-dessous


### PR DESCRIPTION
Ajoute data-sveltekit-reload sur les liens de téléchargement pour que SvelteKit ne les intercepte pas.