### PR TITLE
fix(notification): évite reset "vue" sur resync

### DIFF
--- a/outils/synchronisation-ds/synchronisation-notification.ts
+++ b/outils/synchronisation-ds/synchronisation-notification.ts
@@ -55,13 +55,15 @@ export async function mettreÀjourNotification(
   }
 
   // Mettre à jour la table notification.
-  // Si la date a changé, alors on écrase la notification existante.
-  // Sinon, on ignore (on ne veut pas mettre à jour le champ "vue" si la modification a déjà été vue).
+  // On n'écrase la notification existante que si la date de modification reçue est
+  // STRICTEMENT plus récente que celle stockée. Une date différente mais plus ancienne
+  // (ré-import, ou date de seed > date réelle du dossier) ne doit pas repasser "vue" à false.
+  // Cas NULL : si la date stockée est NULL, toute date reçue non-NULL est considérée plus récente.
   return laTransactionDeSynchronisationDS("notification")
     .insert(notifications)
     .onConflict(["dossier", "personne"])
     .merge()
     .whereRaw(
-      "notification.date_dernière_mise_à_jour IS DISTINCT FROM EXCLUDED.date_dernière_mise_à_jour",
+      "(notification.date_dernière_mise_à_jour IS NULL OR EXCLUDED.date_dernière_mise_à_jour > notification.date_dernière_mise_à_jour)",
     );
 }


### PR DESCRIPTION
###   Origine du bug

  La table notification a été créée par la migration du 2026-03-04, qui a initialisé toutes les notifications existantes avec
  `date_dernière_mise_à_jour = NOW()` (donc le 2026-03-04) et `vue = true`.

  Lors d'une synchronisation DS lancée avec `--lastModified 2024-01-01`, la fenêtre de récupération a été ouverte jusqu'en janvier 2024. La synchro a donc récupéré tous les dossiers de la démarche, chacun avec sa vraie `dateDerniereModification` (souvent ancienne : septembre 2024, etc.).

  Pour chaque dossier suivi, mettreÀjourNotification construit une notification avec vue: false et la vraie date de modification du dossier, puis fait un upsert avec la garde :

  `notification.date_dernière_mise_à_jour IS DISTINCT FROM EXCLUDED.date_dernière_mise_à_jour`

  Pour chaque notification déjà en base (date = 2026-03-04, vue = true), la date entrante (ex. septembre 2024) était différente de la date stockée. La garde `IS DISTINCT FROM` était donc vraie → le merge s'est déclenché et a réécrit `vue = false`, alors que ces dossiers n'avaient en réalité pas été modifiés et avaient déjà été consultés.

  Résultat : un resync historique a repassé en « non vue » l'ensemble des notifications, en les redatant avec leur vraie date de modification (d'où les 147 notifications datées de septembre 2024).

  ### Correctif

  On remplace `IS DISTINCT FROM` par une comparaison strictement plus récente :

`EXCLUDED.date_dernière_mise_à_jour > notification.date_dernière_mise_à_jour`

  Ainsi une date entrante plus ancienne que la date stockée (cas d'un resync ou de la date de seed) ne repasse plus la notification en « non vue ». Seule une modification réellement plus récente marque à nouveau la notification comme non vue.