### PR TITLE
feat(staging): reset DB and S3 on each deploy

### DIFF
--- a/libs/database/scripts/wipe-schema.ts
+++ b/libs/database/scripts/wipe-schema.ts
@@ -1,0 +1,21 @@
+import knexLib from "knex";
+import config from "../knexfile.ts";
+
+// Destructive: drops and recreates the public schema (all tables, data and
+// migration history). Hard guard so this can NEVER run against production —
+// it only proceeds when PUBLIC_PITCHOU_ENV is explicitly "staging".
+if (process.env.PUBLIC_PITCHOU_ENV !== "staging") {
+  console.error(
+    `✗ wipe-schema refused: PUBLIC_PITCHOU_ENV is "${process.env.PUBLIC_PITCHOU_ENV ?? ""}", expected "staging"`,
+  );
+  process.exit(1);
+}
+
+const db = knexLib(config.staging);
+
+try {
+  await db.raw("DROP SCHEMA public CASCADE; CREATE SCHEMA public;");
+  console.log("✔ public schema wiped");
+} finally {
+  await db.destroy();
+}

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -5,6 +5,12 @@
 if [ "$PITCHOU_APP" = "admin" ]; then
   exec node apps/admin/build/index.js
 else
+  if [ "$PUBLIC_PITCHOU_ENV" = "staging" ]; then
+    echo "Resetting staging database (drop + recreate public schema)…"
+    corepack pnpm --filter @pitchou/database exec node --import tsx scripts/wipe-schema.ts || echo "⚠ staging schema wipe failed (non-fatal)"
+    echo "Emptying staging S3 bucket…"
+    aws s3 rm "s3://$S3_BUCKET" --recursive || echo "⚠ staging S3 wipe failed (non-fatal)"
+  fi
   corepack pnpm --filter @pitchou/database exec node --import tsx ./node_modules/knex/bin/cli.js migrate:latest --env production
   if [ "$PUBLIC_PITCHOU_ENV" = "staging" ]; then
     echo "Seeding staging data…"


### PR DESCRIPTION
Wipe the staging database and S3 bucket before migrating + seeding on every deploy, so staging always boots from a clean, seeded state.

- Add libs/database/scripts/wipe-schema.ts: drops + recreates the public schema via Knex (uses the existing pg driver, no psql needed). Hard guard refuses to run unless PUBLIC_PITCHOU_ENV is staging, so it can never touch production.
- scripts/start.sh: on staging deploy, wipe schema then empty the S3 bucket (aws s3 rm --recursive) before migrate:latest and seed:run. Both wipes are non-fatal so a failure doesn't block the deploy.